### PR TITLE
Removed allowBack because this attribute is not required by library

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,6 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.afollestad.materialdialogs">
-
-    <application android:allowBackup="true" />
+<manifest package="com.afollestad.materialdialogs" >
 
 </manifest>


### PR DESCRIPTION
I discovered that merging of my app AndroidManifest fails with AndroidManifest specified by library.
There is workaround to pass merge (which is broken with 0.14.1 android gradle plugin) but I think there is no sense to keep this attribute in library manifest.
