### PR TITLE
Do not enforce use of Activity as Context in MaterialDialog.Builder

### DIFF
--- a/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -461,7 +461,7 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener, 
      */
     public static class Builder {
 
-        protected Activity context;
+        protected Context context;
         protected CharSequence title;
         protected Alignment titleAlignment = Alignment.LEFT;
         protected Alignment contentAlignment = Alignment.LEFT;
@@ -488,7 +488,7 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener, 
         protected boolean hideActions;
         protected boolean autoDismiss = true;
 
-        public Builder(@NonNull Activity context) {
+        public Builder(@NonNull Context context) {
             this.context = context;
             this.positiveText = context.getString(android.R.string.ok);
             final int materialBlue = context.getResources().getColor(R.color.md_material_blue_500);


### PR DESCRIPTION
Allow simple Context to be passed as a constructor to MaterialDialog.Builder. Forcing to use an Activity forbids the use of ContextWrappers that are vital to some applications.

I understand the reason behind it - if you pass the Application context, you will not get Theme attributes, but that should not be your but the developer's concern.
