### PR TITLE
Set min api to 9

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         applicationId "com.afollestad.materialdialogs"
-        minSdkVersion 14
+        minSdkVersion 9
         targetSdkVersion 21
         versionCode 1
         versionName "0.0.8"


### PR DESCRIPTION
Currently material dialogs does not use any apis >9. Min api 9 makes material dialogs available to use in many more projects.
