### PR TITLE
Fix Light theme display on Gingerbread devices. Fix #46

### DIFF
--- a/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -17,7 +17,6 @@ import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import android.text.method.LinkMovementMethod;
-import android.view.ContextThemeWrapper;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -41,7 +40,6 @@ import java.util.List;
  */
 public class MaterialDialog extends DialogBase implements View.OnClickListener, MeasureCallbackScrollView.Callback {
 
-    private Context mContext;
     private ImageView icon;
     private TextView title;
     private View titleFrame;
@@ -72,7 +70,11 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener, 
     private boolean autoDismiss;
 
     MaterialDialog(Builder builder) {
-        super(new ContextThemeWrapper(builder.context, builder.theme == Theme.LIGHT ? R.style.MD_Light : R.style.MD_Dark));
+        super(builder.context, builder.theme == Theme.LIGHT ? R.style.MD_Light : R.style.MD_Dark);
+
+        if (builder.theme == Theme.LIGHT && Build.VERSION.SDK_INT <= Build.VERSION_CODES.GINGERBREAD_MR1) {
+            setInverseBackgroundForced(true);
+        }
 
         this.regularFont = builder.regularFont;
         if (this.regularFont == null)
@@ -81,8 +83,7 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener, 
         if (this.mediumFont == null)
             this.mediumFont = Typeface.createFromAsset(getContext().getResources().getAssets(), "Roboto-Medium.ttf");
 
-        this.mContext = builder.context;
-        this.view = LayoutInflater.from(builder.context).inflate(R.layout.md_dialog, null);
+        this.view = LayoutInflater.from(getContext()).inflate(R.layout.md_dialog, null);
         this.customView = builder.customView;
         this.callback = builder.callback;
         this.listCallback = builder.listCallback;
@@ -194,7 +195,7 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener, 
                 setMargin(view.findViewById(R.id.buttonDefaultFrame), -1, 0, -1, -1);
                 if (items != null && items.length > 0) {
                     View customFrame = view.findViewById(R.id.customViewFrame);
-                    Resources r = mContext.getResources();
+                    Resources r = getContext().getResources();
                     int bottomPadding = view.findViewById(R.id.titleCustomView).getVisibility() == View.VISIBLE ?
                             (int) r.getDimension(R.dimen.md_main_frame_margin) : (int) r.getDimension(R.dimen.md_dialog_frame_margin);
                     customFrame.setPadding(customFrame.getPaddingLeft(), customFrame.getPaddingTop(),
@@ -202,7 +203,7 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener, 
                 }
             } else {
                 view.findViewById(R.id.customViewDivider).setVisibility(View.GONE);
-                final int bottomMargin = (int) mContext.getResources().getDimension(R.dimen.md_button_padding_frame_bottom);
+                final int bottomMargin = (int) getContext().getResources().getDimension(R.dimen.md_button_padding_frame_bottom);
                 setMargin(view.findViewById(R.id.buttonStackedFrame), -1, bottomMargin, -1, -1);
                 setMargin(view.findViewById(R.id.buttonDefaultFrame), -1, bottomMargin, -1, -1);
             }
@@ -221,7 +222,7 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener, 
                 setMargin(view.findViewById(R.id.mainFrame), -1, 0, -1, -1);
                 setMargin(view.findViewById(R.id.buttonStackedFrame), -1, 0, -1, -1);
                 setMargin(view.findViewById(R.id.buttonDefaultFrame), -1, 0, -1, -1);
-                final int conPadding = (int) mContext.getResources().getDimension(R.dimen.md_main_frame_margin);
+                final int conPadding = (int) getContext().getResources().getDimension(R.dimen.md_main_frame_margin);
                 View con = view.findViewById(R.id.content);
                 con.setPadding(con.getPaddingLeft(), 0, con.getPaddingRight(), conPadding);
             } else {
@@ -261,16 +262,16 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener, 
         LinearLayout customFrame = (LinearLayout) view.findViewById(R.id.customViewFrame);
         ((ScrollView) view.findViewById(R.id.customViewScroll)).smoothScrollTo(0, 0);
         setMargin(customFrame, -1, -1, 0, 0);
-        LayoutInflater li = LayoutInflater.from(mContext);
+        LayoutInflater li = LayoutInflater.from(getContext());
 
-        final int customFramePadding = (int) mContext.getResources().getDimension(R.dimen.md_main_frame_margin);
+        final int customFramePadding = (int) getContext().getResources().getDimension(R.dimen.md_main_frame_margin);
         int listPaddingBottom;
         View title = view.findViewById(R.id.titleCustomView);
         if (title.getVisibility() == View.VISIBLE) {
             title.setPadding(customFramePadding, title.getPaddingTop(), customFramePadding, title.getPaddingBottom());
             listPaddingBottom = customFramePadding;
         } else {
-            listPaddingBottom = (int) mContext.getResources().getDimension(R.dimen.md_main_frame_margin);
+            listPaddingBottom = (int) getContext().getResources().getDimension(R.dimen.md_main_frame_margin);
         }
         if (positiveText != null) listPaddingBottom = 0;
         customFrame.setPadding(customFrame.getPaddingLeft(), customFrame.getPaddingTop(),
@@ -328,8 +329,8 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener, 
          * From: http://www.google.com/design/spec/components/dialogs.html#dialogs-specs
          */
         final int dialogWidth = getWindow().getDecorView().getMeasuredWidth();
-        final int eightDp = (int) mContext.getResources().getDimension(R.dimen.md_button_padding_horizontal_external);
-        final int sixteenDp = (int) mContext.getResources().getDimension(R.dimen.md_button_padding_frame_side);
+        final int eightDp = (int) getContext().getResources().getDimension(R.dimen.md_button_padding_horizontal_external);
+        final int sixteenDp = (int) getContext().getResources().getDimension(R.dimen.md_button_padding_frame_side);
         return (dialogWidth - sixteenDp - sixteenDp - eightDp) / 2;
     }
 
@@ -362,7 +363,7 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener, 
         }
         final int maxWidth = calculateMaxButtonWidth();
         final Paint paint = positiveButton.getPaint();
-        final int eightDp = (int) mContext.getResources().getDimension(R.dimen.md_button_padding_horizontal_external);
+        final int eightDp = (int) getContext().getResources().getDimension(R.dimen.md_button_padding_horizontal_external);
         final int positiveWidth = (int) paint.measureText(positiveButton.getText().toString()) + (eightDp * 2);
         isStacked = positiveWidth > maxWidth;
         if (!isStacked && this.neutralText != null) {
@@ -928,7 +929,7 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener, 
      * @param titleRes The string resource of the new title of the action button.
      */
     public final void setActionButton(DialogAction which, @StringRes int titleRes) {
-        setActionButton(which, mContext.getString(titleRes));
+        setActionButton(which, getContext().getString(titleRes));
     }
 
     /**
@@ -952,7 +953,7 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener, 
 
     @Override
     public void setIconAttribute(int attrId) {
-        Drawable d = DialogUtils.resolveDrawable(mContext, attrId);
+        Drawable d = DialogUtils.resolveDrawable(getContext(), attrId);
         icon.setImageDrawable(d);
         icon.setVisibility(d != null ? View.VISIBLE : View.GONE);
     }

--- a/library/src/main/java/com/afollestad/materialdialogs/base/DialogBase.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/base/DialogBase.java
@@ -24,8 +24,8 @@ public class DialogBase extends AlertDialog implements DialogInterface.OnShowLis
     protected final static String NEUTRAL = "NEUTRAL";
     private OnShowListener mShowListener;
 
-    protected DialogBase(Context context) {
-        super(context);
+    protected DialogBase(Context context, int theme) {
+        super(context, theme);
     }
 
     public static void setMargin(View view, int top, int bottom, int left, int right) {

--- a/library/src/main/res/values-v11/styles.xml
+++ b/library/src/main/res/values-v11/styles.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="MD_Light" parent="android:Theme.Holo.Light.Dialog">
+        <item name="md_divider">@color/md_divider_black</item>
+        <item name="md_selector">@drawable/md_selector</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+    </style>
+
+    <style name="MD_Dark" parent="android:Theme.Holo.Dialog">
+        <item name="md_divider">@color/md_divider_white</item>
+        <item name="md_selector">@drawable/md_selector_dark</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+    </style>
+
+</resources>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="MD_Light" parent="android:Theme.Holo.Light">
+    <style name="MD_Light" parent="Theme_Light_Dialog">
         <item name="md_divider">@color/md_divider_black</item>
         <item name="md_selector">@drawable/md_selector</item>
     </style>
 
-    <style name="MD_Dark" parent="android:Theme.Holo">
+    <style name="MD_Dark" parent="android:Theme.Dialog">
         <item name="md_divider">@color/md_divider_white</item>
         <item name="md_selector">@drawable/md_selector_dark</item>
+        <item name="android:windowFrame">@null</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowContentOverlay">@null</item>
     </style>
 
     <style name="MD_ActionButtonStacked" parent="@style/MD_ActionButton">
@@ -36,6 +39,15 @@
         <item name="android:paddingLeft">@dimen/md_button_padding_horizontal_internal</item>
         <item name="android:paddingRight">@dimen/md_button_padding_horizontal_internal</item>
         <item name="android:layout_marginLeft">@dimen/md_button_padding_horizontal_external</item>
+    </style>
+
+    <!-- Light dialog theme for devices prior Honeycomb -->
+    <style name="Theme_Light_Dialog" parent="android:Theme.Light">
+        <item name="android:windowFrame">@null</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowAnimationStyle">@android:style/Animation.Dialog</item>
     </style>
 
 </resources>


### PR DESCRIPTION
This PR fixes Light theme display on Gingerbread devices, see #46.

On Gingerbread devices, the context is always wrapped inside a ContextThemeWrapper (see https://github.com/android/platform_frameworks_base/blob/gingerbread-release/core/java/android/app/Dialog.java#L139 ). As a result, the custom theme is always overrided with the default dark theme.

As a workaround, use the other constructor of AlertDialog which take a theme resource ID as a second argument.

The second issue was the use of Theme.Holo on pre API 11. I used the correct themes for Gingerbread, and created an new themes files for API 11 which inherits from Holo dialog themes.

Tested on Gingerbread, KitKat and Lollipop with success.
