### PR TITLE
Fixed issue with callbacks not being called when there was no positive button...

### DIFF
--- a/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -515,15 +515,17 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener, 
                 if (!cb.isChecked())
                     cb.setChecked(true);
                 invalidateSingleChoice(index);
-                if (!hasActionButtons()) {
-                    // Immediately send the selection callback without dismissing if no action buttons are shown
+                if (positiveText == null) {
+                    // Immediately send the selection callback if no positive button is shown
+                    if (autoDismiss) dismiss();
                     sendSingleChoiceCallback(v);
                 }
             } else if (listCallbackMulti != null) {
                 CheckBox cb = (CheckBox) ((LinearLayout) v).getChildAt(0);
                 cb.setChecked(!cb.isChecked());
-                if (!hasActionButtons()) {
-                    // Immediately send the selection callback without dismissing if no action buttons are shown
+                if (positiveText == null) {
+                    // Immediately send the selection callback if no positive button is shown
+                    if (autoDismiss) dismiss();
                     sendMultichoiceCallback();
                 }
             } else if (autoDismiss) dismiss();


### PR DESCRIPTION
... but there were other action buttons. If there is a positive button it will be used to trigger the callbacks. But when it is not present, the callbacks need to be called on each change produced by a click since no click on a positive button will trigger them.
