### PR TITLE
Enabled/disabled colour for positive/neutral/negative button

### DIFF
--- a/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -868,14 +868,14 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener, 
 
 
     private ColorStateList getActionTextStateList(int newPrimaryColor) {
-        final int buttonColor = DialogUtils.resolveColor(getContext(), android.R.attr.textColorPrimary);
-        if (newPrimaryColor == 0) newPrimaryColor = buttonColor;
+        final int fallBackButtonColor = DialogUtils.resolveColor(getContext(), android.R.attr.textColorPrimary);
+        if (newPrimaryColor == 0) newPrimaryColor = fallBackButtonColor;
         int[][] states = new int[][]{
                 new int[]{-android.R.attr.state_enabled}, // disabled
                 new int[]{} // enabled
         };
         int[] colors = new int[]{
-                DialogUtils.adjustAlpha(buttonColor, 0.6f),
+                DialogUtils.adjustAlpha(newPrimaryColor, 0.4f),
                 newPrimaryColor
         };
         return new ColorStateList(states, colors);


### PR DESCRIPTION
Changed colour of disabled button text to be a faded version of its enabled colour instead of the dark grey that can currently be seen. This behaviour can be seen in original Lollipop system dialogues, e.g., in the Add Network dialogue of the Settings app (faded/disabled SAVE button)
