### PR TITLE
Remove state-list animation for action buttons on 5.0+

### DIFF
--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -31,6 +31,7 @@
         <item name="android:layout_width">wrap_content</item>
         <item name="android:text">@android:string/ok</item>
         <item name="android:textSize">@dimen/md_button_textsize</item>
+        <item name="android:stateListAnimator">@null</item>
         <item name="android:textAllCaps">true</item>
         <item name="android:gravity">center</item>
         <item name="android:singleLine">true</item>


### PR DESCRIPTION
In commit 3e8ed207a68be525f0097a94c4c47526acc61fbe, the action buttons were changed to `Button`s from `TextView`s.
Due to the default style for buttons, they create shadows when pressed, which is not supposed to happen for flat buttons in a dialog. 
This overrides that attribute.
