### PR TITLE
Fix getSelectedIndices and a few tweaks to ButtonCallback

### DIFF
--- a/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -1183,11 +1183,7 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener, 
     @Nullable
     public Integer[] getSelectedIndices() {
         if (listCallbackMulti != null) {
-            Integer[] returnedIndicies = new Integer[selectedIndicesList.size()];
-            for (int i = 0; i < selectedIndicesList.size(); i++) {
-                returnedIndicies[i] = selectedIndicesList.get(i);
-            }
-            return returnedIndicies;
+            return selectedIndicesList.toArray(new Integer[selectedIndicesList.size()]);
         } else {
             return null;
         }


### PR DESCRIPTION
Two parts
- Fix getSelectedIndices
- Tweak ButtonCallback to make it easier for developers. This marks it as abstract (so the user knows they need to implement it) and also marks the inherited base object methods as final so that it's not confusing for the user. Basically makes it behave more similarly to an interface.

![screenshot 2014-12-20 21 10 43](https://cloud.githubusercontent.com/assets/1361086/5517245/be892420-888c-11e4-8ede-88943bb6eed5.png)
![screenshot 2014-12-20 21 10 55](https://cloud.githubusercontent.com/assets/1361086/5517244/be884672-888c-11e4-99c0-ac3196971853.png)
