### PR TITLE
Fix multichoice list items not updating correctly if no pre-selected indices given

### DIFF
--- a/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -1426,11 +1426,9 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener {
                     break;
                 }
                 case MULTI: {
-                    if (mBuilder.selectedIndices != null) {
-                        @SuppressLint("CutPasteId")
-                        CheckBox checkbox = (CheckBox) view.findViewById(R.id.control);
-                        checkbox.setChecked(selectedIndicesList.contains(index));
-                    }
+                    @SuppressLint("CutPasteId")
+                    CheckBox checkbox = (CheckBox) view.findViewById(R.id.control);
+                    checkbox.setChecked(selectedIndicesList.contains(index));
                     break;
                 }
             }


### PR DESCRIPTION
The null check was unnecessary on builder's selected indices was unnecesary, as it only checks `selectedIndicesList`. So if `null` was passed in for `selectedIndices`, would would permanently skip updating the fields.

Git blame says [you](https://github.com/afollestad/material-dialogs/commit/2e859fda38e9c09c8f2103264266500b0c485a95#diff-f3e62b50bd1b0ff34ab2d02ea80b7b78R1202) did this :wink: 