### PR TITLE
Switch gravity to enum and make RecyclerView a provided dependency

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:21.0.3'
     compile 'com.android.support:support-annotations:21.0.3'
-    compile 'com.android.support:recyclerview-v7:21.0.3'
+    provided 'com.android.support:recyclerview-v7:21.0.3'
 }
 
 publish {

--- a/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -16,13 +16,10 @@ import android.support.annotation.ArrayRes;
 import android.support.annotation.AttrRes;
 import android.support.annotation.ColorRes;
 import android.support.annotation.DrawableRes;
-import android.support.annotation.IntDef;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
-import android.support.v7.widget.GridLayoutManager;
-import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.text.method.LinkMovementMethod;
 import android.view.ContextThemeWrapper;
@@ -56,17 +53,6 @@ import java.util.List;
  * @author Aidan Follestad (afollestad)
  */
 public class MaterialDialog extends DialogBase implements View.OnClickListener {
-
-    @IntDef({START, CENTER, END})
-    public @interface GravityInt {
-    }
-
-    @SuppressWarnings("WeakerAccess")
-    public static final int START = 0;
-    @SuppressWarnings("WeakerAccess")
-    public static final int CENTER = 1;
-    @SuppressWarnings("WeakerAccess")
-    public static final int END = 2;
 
     protected final View view;
     protected final Builder mBuilder;
@@ -296,7 +282,7 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener {
         }
     }
 
-    private static int gravityIntToGravity(@GravityInt int gravity) {
+    private static int gravityIntToGravity(GravityEnum gravity) {
         switch (gravity) {
             case CENTER:
                 return Gravity.CENTER_HORIZONTAL;
@@ -308,7 +294,7 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener {
     }
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
-    private static int gravityToAlignment(@GravityInt int gravity) {
+    private static int gravityToAlignment(GravityEnum gravity) {
         switch (gravity) {
             case CENTER:
                 return View.TEXT_ALIGNMENT_CENTER;
@@ -803,12 +789,8 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener {
 
         protected final Context context;
         protected CharSequence title;
-        protected
-        @GravityInt
-        int titleGravity = Gravity.START;
-        protected
-        @GravityInt
-        int contentGravity = Gravity.START;
+        protected GravityEnum titleGravity = GravityEnum.START;
+        protected GravityEnum contentGravity = GravityEnum.START;
         protected int titleColor = -1;
         protected int contentColor = -1;
         protected CharSequence content;
@@ -908,7 +890,7 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener {
             return this;
         }
 
-        public Builder titleGravity(@GravityInt int gravity) {
+        public Builder titleGravity(GravityEnum gravity) {
             this.titleGravity = gravity;
             return this;
         }
@@ -976,7 +958,7 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener {
             return this;
         }
 
-        public Builder contentGravity(@GravityInt int gravity) {
+        public Builder contentGravity(GravityEnum gravity) {
             this.contentGravity = gravity;
             return this;
         }
@@ -1536,6 +1518,10 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener {
                     throw new IllegalArgumentException("Not a valid list type");
             }
         }
+    }
+
+    public static enum GravityEnum {
+        START, CENTER, END
     }
 
     public static interface ListCallback {

--- a/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -535,8 +535,8 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener {
             return canAdapterViewScroll((AdapterView) view);
         } else if (view instanceof WebView) {
             return canWebViewScroll((WebView) view);
-        } else if (view instanceof RecyclerView) {
-            return canRecyclerViewScroll((RecyclerView) view);
+        } else if (isRecyclerView(view)) {
+            return RecyclerUtil.canRecyclerViewScroll((RecyclerView) view);
         } else {
             if (atBottom) {
                 return canViewOrChildScroll(getBottomView((ViewGroup) view), true);
@@ -546,6 +546,17 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener {
         }
     }
 
+    private static boolean isRecyclerView(View view) {
+        boolean isRecyclerView = false;
+        try {
+            Class.forName("android.support.v7.widget.RecyclerView");
+
+            // We got here, so now we can safely check
+            isRecyclerView = view instanceof RecyclerView;
+        } catch (ClassNotFoundException ignored) {}
+
+        return isRecyclerView;
+    }
 
     private static boolean canWebViewScroll(WebView view) {
         return view.getMeasuredHeight() > view.getContentHeight();
@@ -569,28 +580,6 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener {
         public NotImplementedException(String message) {
             super(message);
         }
-    }
-
-    private static boolean canRecyclerViewScroll(RecyclerView rv) {
-        final RecyclerView.LayoutManager lm = rv.getLayoutManager();
-        final int count = rv.getAdapter().getItemCount();
-        int lastVisible;
-
-        if (lm instanceof LinearLayoutManager) {
-            LinearLayoutManager llm = (LinearLayoutManager) lm;
-            lastVisible = llm.findLastVisibleItemPosition();
-        } else if (lm instanceof GridLayoutManager) {
-            GridLayoutManager glm = (GridLayoutManager) lm;
-            lastVisible = glm.findLastVisibleItemPosition();
-        } else {
-            throw new NotImplementedException("Material Dialogs currently only supports LinearLayoutManager and GridLayoutManager. Please report any new layout managers.");
-        }
-
-        if (lastVisible == -1)
-            return false;
-        /* We scroll if the last item is not visible */
-        final boolean lastItemVisible = lastVisible == count - 1;
-        return !lastItemVisible || rv.getChildAt(rv.getChildCount() - 1).getBottom() > rv.getHeight() - rv.getPaddingBottom();
     }
 
     /**

--- a/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -20,7 +20,6 @@ import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
-import android.support.v7.widget.RecyclerView;
 import android.text.method.LinkMovementMethod;
 import android.view.ContextThemeWrapper;
 import android.view.Gravity;
@@ -522,7 +521,7 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener {
         } else if (view instanceof WebView) {
             return canWebViewScroll((WebView) view);
         } else if (isRecyclerView(view)) {
-            return RecyclerUtil.canRecyclerViewScroll((RecyclerView) view);
+            return RecyclerUtil.canRecyclerViewScroll(view);
         } else {
             if (atBottom) {
                 return canViewOrChildScroll(getBottomView((ViewGroup) view), true);
@@ -538,7 +537,7 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener {
             Class.forName("android.support.v7.widget.RecyclerView");
 
             // We got here, so now we can safely check
-            isRecyclerView = view instanceof RecyclerView;
+            isRecyclerView = RecyclerUtil.isRecyclerView(view);
         } catch (ClassNotFoundException ignored) {}
 
         return isRecyclerView;

--- a/library/src/main/java/com/afollestad/materialdialogs/RecyclerUtil.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/RecyclerUtil.java
@@ -1,0 +1,29 @@
+package com.afollestad.materialdialogs;
+
+import android.support.v7.widget.GridLayoutManager;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+
+public class RecyclerUtil {
+    static boolean canRecyclerViewScroll(RecyclerView rv) {
+        final RecyclerView.LayoutManager lm = rv.getLayoutManager();
+        final int count = rv.getAdapter().getItemCount();
+        int lastVisible;
+
+        if (lm instanceof LinearLayoutManager) {
+            LinearLayoutManager llm = (LinearLayoutManager) lm;
+            lastVisible = llm.findLastVisibleItemPosition();
+        } else if (lm instanceof GridLayoutManager) {
+            GridLayoutManager glm = (GridLayoutManager) lm;
+            lastVisible = glm.findLastVisibleItemPosition();
+        } else {
+            throw new MaterialDialog.NotImplementedException("Material Dialogs currently only supports LinearLayoutManager and GridLayoutManager. Please report any new layout managers.");
+        }
+
+        if (lastVisible == -1)
+            return false;
+        /* We scroll if the last item is not visible */
+        final boolean lastItemVisible = lastVisible == count - 1;
+        return !lastItemVisible || rv.getChildAt(rv.getChildCount() - 1).getBottom() > rv.getHeight() - rv.getPaddingBottom();
+    }
+}

--- a/library/src/main/java/com/afollestad/materialdialogs/RecyclerUtil.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/RecyclerUtil.java
@@ -3,9 +3,13 @@ package com.afollestad.materialdialogs;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.view.View;
 
 public class RecyclerUtil {
-    static boolean canRecyclerViewScroll(RecyclerView rv) {
+    static boolean canRecyclerViewScroll(View view) {
+
+        RecyclerView rv = (RecyclerView) view;
+
         final RecyclerView.LayoutManager lm = rv.getLayoutManager();
         final int count = rv.getAdapter().getItemCount();
         int lastVisible;
@@ -25,5 +29,9 @@ public class RecyclerUtil {
         /* We scroll if the last item is not visible */
         final boolean lastItemVisible = lastVisible == count - 1;
         return !lastItemVisible || rv.getChildAt(rv.getChildCount() - 1).getBottom() > rv.getHeight() - rv.getPaddingBottom();
+    }
+
+    static boolean isRecyclerView(View view) {
+        return view instanceof RecyclerView;
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -19,5 +19,4 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':library')
-    compile 'com.android.support:recyclerview-v7:21.0.3'
 }

--- a/sample/src/main/java/com/afollestad/materialdialogssample/MainActivity.java
+++ b/sample/src/main/java/com/afollestad/materialdialogssample/MainActivity.java
@@ -431,7 +431,7 @@ public class MainActivity extends ActionBarActivity implements FolderSelectorDia
                 .negativeText(R.string.disagree)
                 .positiveColorRes(R.color.material_red_400)
                 .negativeColorRes(R.color.material_red_400)
-                .titleGravity(MaterialDialog.CENTER)
+                .titleGravity(MaterialDialog.GravityEnum.CENTER)
                 .titleColorRes(R.color.material_red_400)
                 .contentColorRes(android.R.color.white)
                 .backgroundColorRes(R.color.material_blue_grey_800)


### PR DESCRIPTION
Two things

* As pointed out in #165, due to the restrictions of AARs we cannot safely use IntDef. This switches gravity (one more time...) to straight enums. Sorry for the hassle folks, AARs will hopefully be improved in the future :frowning: 
* Switch recyclerview to be a `provided` dependency. This allows you to include support for it without actually requiring it. This is good so you can avoid including it as a transitive library, especially when your usage of it is just to check instance of and scroll state. This moves all the recyclerview-dependent code to a separate Util class, which in turn is *only* called once it's been verified that the user included RecyclerView in the classpath. If the user didn't include recyclerview, it just skips over it and continues as usual. Generally in libraries, you tend to want to avoid having many (if any) dependencies. That's the best way to ensure it stays lean, modular, and doesn't dissuade dependency-weary developers from using it :)