### PR TITLE
Add application tag to AndroidManifest.xml

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest package="com.afollestad.materialdialogs">
-
+ 
+    <application />
 
 </manifest>


### PR DESCRIPTION
In order to use Robolectric library there is a need to have <application \> tag defined in the android manifest.

relative pull https://github.com/robolectric/robolectric/pull/1309