### PR TITLE
Fix button stacking when positive button text is very long

### DIFF
--- a/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -616,9 +616,14 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener {
         }
         isStacked = false;
         int buttonsWidth = 0;
-        if (mBuilder.positiveText != null) buttonsWidth += positiveButton.getWidth();
-        if (mBuilder.neutralText != null) buttonsWidth += neutralButton.getWidth();
-        if (mBuilder.negativeText != null) buttonsWidth += negativeButton.getWidth();
+
+        positiveButton.measure(View.MeasureSpec.UNSPECIFIED,View.MeasureSpec.UNSPECIFIED);
+        neutralButton.measure(View.MeasureSpec.UNSPECIFIED,View.MeasureSpec.UNSPECIFIED);
+        negativeButton.measure(View.MeasureSpec.UNSPECIFIED,View.MeasureSpec.UNSPECIFIED);
+
+        if (mBuilder.positiveText != null) buttonsWidth += positiveButton.getMeasuredWidth();
+        if (mBuilder.neutralText != null) buttonsWidth += neutralButton.getMeasuredWidth();
+        if (mBuilder.negativeText != null) buttonsWidth += negativeButton.getMeasuredWidth();
 
         final int buttonFrameWidth = view.findViewById(R.id.buttonDefaultFrame).getWidth();
         isStacked = buttonsWidth > buttonFrameWidth;


### PR DESCRIPTION
getWidth() doesn't always returns the total width of the buttons if they don't fit in the layout. Using getMeasuredWidth() instead and doing a measure() pass with UNSPECIFIED MeasureSpec to get the full width.