### PR TITLE
MaterialEditTextPreference should display persisted value or default value

### DIFF
--- a/library/src/main/java/com/afollestad/materialdialogs/prefs/MaterialEditTextPreference.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/prefs/MaterialEditTextPreference.java
@@ -2,6 +2,7 @@ package com.afollestad.materialdialogs.prefs;
 
 import android.app.Dialog;
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.graphics.PorterDuff;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
@@ -29,9 +30,14 @@ public class MaterialEditTextPreference extends DialogPreference {
 
     private int mColor = 0;
     private EditText mEditText;
+    private String mValue;
 
     public EditText getEditText() {
         return mEditText;
+    }
+
+    public void setValue(String value){
+        mValue = value;
     }
 
     public void setText(String text) {
@@ -69,11 +75,11 @@ public class MaterialEditTextPreference extends DialogPreference {
         // Create our layout, put the EditText inside, then add to dialog
         ViewGroup layout = (ViewGroup) LayoutInflater.from(context).inflate(R.layout.md_input_dialog, null);
         mEditText = (EditText) layout.findViewById(android.R.id.edit);
+        mEditText.setText(mValue);
 
         // Color our EditText if need be. Lollipop does it by default
         if (VERSION.SDK_INT < VERSION_CODES.LOLLIPOP)
             mEditText.getBackground().setColorFilter(mColor, PorterDuff.Mode.SRC_ATOP);
-
 
         TextView message = (TextView) layout.findViewById(android.R.id.message);
         if (getDialogMessage() != null && getDialogMessage().toString().length() > 0) {
@@ -115,5 +121,21 @@ public class MaterialEditTextPreference extends DialogPreference {
     private void requestInputMethod(Dialog dialog) {
         Window window = dialog.getWindow();
         window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+    }
+
+    /**
+     * Called when the default value attribute needs to be read
+     */
+    @Override
+    protected Object onGetDefaultValue(TypedArray a, int index) {
+        return a.getString(index);
+    }
+
+    /**
+     * Called on initialization, defaultValue populated only if onGetDefaultValue is overriden
+     */
+    @Override
+    protected void onSetInitialValue(boolean restorePersistedValue, Object defaultValue) {
+        setValue(restorePersistedValue ? getPersistedString("") : defaultValue.toString());
     }
 }

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -131,6 +131,7 @@
     <string name="edittext_pref_title">Material EditText Preference</string>
     <string name="edittext_pref_desc">This is an example of an EditText preference that automatically uses Material Dialogs to show the input dialog.</string>
     <string name="edittext_pref_dialogtitle">Enter a Name</string>
+    <string name="edittext_pref_optionalvalue">Default value</string>
     <string name="progress_dialog_indeterminate">Progress Dialog (Indeterminate)</string>
     <string name="progress_dialog">Progress Dialog</string>
     <string name="please_wait">Please wait…</string>

--- a/sample/src/main/res/xml/preferences.xml
+++ b/sample/src/main/res/xml/preferences.xml
@@ -18,6 +18,7 @@
         android:dialogTitle="@string/edittext_pref_dialogtitle"
         android:dialogMessage="@string/optional_dialog_message"
         android:persistent="true"
+        android:defaultValue="@string/edittext_pref_optionalvalue"
         android:layout="@layout/preference_custom" />
 
 </PreferenceScreen>


### PR DESCRIPTION
This pull request allows `MaterialEditTextPreference` to 

* display the current persisted value
* display the `android:defaultValue` if a persisted value is not available

At the moment the dialog only saves values but does not display the value.