### PR TITLE
Added option to set maximum icon size

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ new MaterialDialog.Builder(this)
         .show();
 ```
 
+You can limit the maximum size of the icon through the `limitIconToDefaultSize()` or `maxIconSize(int size)` builder method.
+
 ---
 
 ### Stacked Action Buttons
@@ -398,6 +400,16 @@ or operating system. This behavior can be overridden in your Activity themes:
         Applies an icon next to the title in all dialogs.
     -->
     <item name="md_icon">@drawable/ic_launcher</item>
+  
+    <!--
+        Limit icon to a max size.
+    -->
+    <attr name="md_icon_max_size" format="dimension" />
+    
+    <!--
+        Limit the icon to a default max size (32dp).
+    -->
+    <attr name="md_icon_limit_icon_to_default_size" format="boolean" />
 
     <!--
         By default, the title text color is derived from the

--- a/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -273,6 +273,23 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener {
             }
         }
 
+        int maxIconSize = builder.maxIconSize;
+        if (maxIconSize == -1) {
+            maxIconSize = DialogUtils.resolveDimension(mBuilder.context, R.attr.md_icon_max_size);
+        }
+
+        boolean limitIconToDefaultSize = DialogUtils.resolveBoolean(mBuilder.context, R.attr.md_icon_limit_icon_to_default_size);
+        if (builder.limitIconToDefaultSize || limitIconToDefaultSize) {
+            maxIconSize = mBuilder.context.getResources().getDimensionPixelSize(R.dimen.md_icon_max_size);
+        }
+
+        if (maxIconSize > -1) {
+            icon.setAdjustViewBounds(true);
+            icon.setMaxHeight(maxIconSize);
+            icon.setMaxWidth(maxIconSize);
+            icon.requestLayout();
+        }
+
         if (builder.title == null) {
             titleFrame.setVisibility(View.GONE);
         } else {
@@ -917,6 +934,8 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener {
         protected Typeface mediumFont;
         protected boolean useCustomFonts;
         protected Drawable icon;
+        protected boolean limitIconToDefaultSize;
+        protected int maxIconSize = -1;
         protected ListAdapter adapter;
         protected OnDismissListener dismissListener;
         protected OnCancelListener cancelListener;
@@ -1457,6 +1476,16 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener {
          */
         public Builder adapter(@NonNull ListAdapter adapter) {
             this.adapter = adapter;
+            return this;
+        }
+
+        public Builder limitIconToDefaultSize() {
+            this.limitIconToDefaultSize = true;
+            return this;
+        }
+
+        public Builder maxIconSize(int maxIconSize) {
+            this.maxIconSize = maxIconSize;
             return this;
         }
 

--- a/library/src/main/java/com/afollestad/materialdialogs/util/DialogUtils.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/util/DialogUtils.java
@@ -47,4 +47,26 @@ public class DialogUtils {
             a.recycle();
         }
     }
+
+    public static int resolveDimension(Context context, @AttrRes int attr) {
+        return resolveDimension(context, attr, -1);
+    }
+
+    public static int resolveDimension(Context context, @AttrRes int attr, int fallback) {
+        TypedArray a = context.getTheme().obtainStyledAttributes(new int[]{attr});
+        try {
+            return a.getDimensionPixelSize(0, fallback);
+        } finally {
+            a.recycle();
+        }
+    }
+
+    public static boolean resolveBoolean(Context context, @AttrRes int attr) {
+        TypedArray a = context.getTheme().obtainStyledAttributes(new int[]{attr});
+        try {
+            return a.getBoolean(0, false);
+        } finally {
+            a.recycle();
+        }
+    }
 }

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -9,6 +9,9 @@
     <attr name="md_background_color" format="color" />
 
     <attr name="md_icon" format="reference" />
+    <attr name="md_icon_max_size" format="dimension" />
+    <attr name="md_icon_limit_icon_to_default_size" format="boolean" />
+
     <attr name="md_title_color" format="color" />
     <attr name="md_content_color" format="color" />
 

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -33,6 +33,7 @@
     <dimen name="md_listitem_height">52dp</dimen>
     <dimen name="md_listitem_control_margin">16dp</dimen>
     <dimen name="md_icon_margin">16dp</dimen>
+    <dimen name="md_icon_max_size">32dp</dimen>
     <dimen name="md_listitem_margin_left">24dp</dimen>
     <dimen name="md_action_corner_radius">2dp</dimen>
 


### PR DESCRIPTION
This pull request allows setting maximum icon size through the following methods:
* to a default limit of 32dp (based from the platform AlertDialog)
  * `limitIconToDefaultSize()` builder method
  * `md_icon_limit_icon_to_default_size` global theme attribute
* to a specified maximum size
  * `maxIconSize(int maxIconSize)` builder method
  * `md_icon_max_size` global theme attribute

This feature was requested in #297. 