### PR TITLE
Fix dialog resize glitches

### DIFF
--- a/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -81,8 +81,6 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener {
     protected ListType listType;
     protected List<Integer> selectedIndicesList;
 
-    private int lastDialogHeight;
-
     private static ContextThemeWrapper getTheme(Builder builder) {
         TypedArray a = builder.context.getTheme().obtainStyledAttributes(new int[]{R.attr.md_dark_theme});
         boolean darkTheme = builder.theme == Theme.DARK;

--- a/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -9,7 +9,6 @@ import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
-import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
@@ -81,6 +80,8 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener {
     protected final int defaultItemColor;
     protected ListType listType;
     protected List<Integer> selectedIndicesList;
+
+    private int lastDialogHeight;
 
     private static ContextThemeWrapper getTheme(Builder builder) {
         TypedArray a = builder.context.getTheme().obtainStyledAttributes(new int[]{R.attr.md_dark_theme});
@@ -327,9 +328,7 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener {
                 new ViewTreeObserver.OnGlobalLayoutListener() {
                     @Override
                     public void onGlobalLayout() {
-                        if (view.getMeasuredWidth() > 0) {
-                            invalidateCustomViewAssociations();
-                        }
+                        invalidateCustomViewAssociations();
                     }
                 });
 
@@ -456,35 +455,23 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener {
             titleBarDivider.setVisibility(View.VISIBLE);
             titleBarDivider.setBackgroundColor(mBuilder.dividerColor);
         } else {
-            titleBarDivider.setVisibility(View.GONE);
+            titleBarDivider.setVisibility(View.INVISIBLE);
         }
 
         View buttonBarDivider = view.findViewById(R.id.buttonBarDivider);
         if (bottomVisible) {
             buttonBarDivider.setVisibility(View.VISIBLE);
             buttonBarDivider.setBackgroundColor(mBuilder.dividerColor);
-            setVerticalMargins(view.findViewById(R.id.buttonStackedFrame), 0, 0);
-            setVerticalMargins(view.findViewById(R.id.buttonDefaultFrame), 0, 0);
+
+            setVerticalMargins(view.findViewById(R.id.buttonStackedFrame), -1, 0);
+            setVerticalMargins(view.findViewById(R.id.buttonDefaultFrame), -1, 0);
         } else {
+            buttonBarDivider.setVisibility(View.INVISIBLE);
+
             Resources r = getContext().getResources();
-            buttonBarDivider.setVisibility(View.GONE);
-
             final int bottomMargin = r.getDimensionPixelSize(R.dimen.md_button_frame_vertical_padding);
-
-            /* Only enable the bottom margin if our available window space can hold the margin,
-               we don't want to enable this and cause the content to scroll, which is bad
-               experience itself but it also causes a vibrating window as this will keep getting
-               enabled/disabled over and over again.
-             */
-            Rect maxWindowFrame = new Rect();
-            getWindow().getDecorView().getWindowVisibleDisplayFrame(maxWindowFrame);
-            int currentHeight = getWindow().getDecorView().getMeasuredHeight();
-            if (currentHeight + bottomMargin < maxWindowFrame.height()) {
-                setVerticalMargins(view.findViewById(R.id.buttonStackedFrame),
-                        bottomMargin, bottomMargin);
-                setVerticalMargins(view.findViewById(R.id.buttonDefaultFrame),
-                        bottomMargin, bottomMargin);
-            }
+            setVerticalMargins(view.findViewById(R.id.buttonStackedFrame), -1, bottomMargin);
+            setVerticalMargins(view.findViewById(R.id.buttonDefaultFrame), -1, bottomMargin);
         }
     }
 

--- a/library/src/main/res/layout/md_dialog.xml
+++ b/library/src/main/res/layout/md_dialog.xml
@@ -94,7 +94,7 @@
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_marginTop="-1dp"
-        android:visibility="gone" />
+        android:visibility="invisible" />
 
     <RelativeLayout
         android:id="@+id/buttonDefaultFrame"
@@ -153,7 +153,6 @@
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/md_button_frame_vertical_padding"
         android:layout_marginBottom="@dimen/md_button_frame_vertical_padding">
 
         <FrameLayout

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -15,14 +15,6 @@
     <!-- 16dp - 4dp (inset) -->
     <dimen name="md_button_padding_frame_side">12dp</dimen>
     <dimen name="md_neutral_button_margin">12dp</dimen>
-    <!--
-            Applied to content scrollview/listview and customview, the spec calls for 16dp between the
-             bottom of the content and the top of the button bar, we split this between the two for
-             ease of layouts and adjustments. Likewise the spec implies 16dp between the title and
-             content and we split that as well.
-
-             Splitting makes it easier to have consistent padding against the dividers.
-    -->
     <dimen name="md_content_vertical_padding">16dp</dimen>
     <dimen name="md_button_frame_vertical_padding">8dp</dimen>
     <dimen name="md_button_height">48dp</dimen>

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -2,7 +2,7 @@
     <!-- See http://www.google.com/design/spec/components/dialogs.html#dialogs-specs -->
     <!-- Margin around the dialog, excluding the button bar -->
     <dimen name="md_dialog_frame_margin">24dp</dimen>
-    <dimen name="md_title_frame_margin_bottom">16dp</dimen>
+    <dimen name="md_title_frame_margin_bottom">8dp</dimen>
     <dimen name="md_title_frame_margin_bottom_list">4dp</dimen>
     <dimen name="md_button_min_width">42dp</dimen>
     <!-- Above and below buttons, 36+12=48 for the height of the button frame -->
@@ -23,7 +23,7 @@
 
              Splitting makes it easier to have consistent padding against the dividers.
     -->
-    <dimen name="md_content_vertical_padding">8dp</dimen>
+    <dimen name="md_content_vertical_padding">16dp</dimen>
     <dimen name="md_button_frame_vertical_padding">8dp</dimen>
     <dimen name="md_button_height">48dp</dimen>
     <dimen name="md_title_textsize">20sp</dimen>


### PR DESCRIPTION
After these changes all of the dialogs in the sample app look as before. However, dialog resizing is much less glitchy. The dividers being set to "gone" and the changing margins were causing lots of dialog redraws and relayouts. Then as we listen onGlobalLayout and relayout everything it forms a cycle.

This only noticeable glitch that remains after these changes is that when the margin below the buttons is hidden (when the divider is shown), you see the buttons move into place.