### PR TITLE
Add option to set alwaysCallMultiChoiceCallback to AlertDialogWrapper

### DIFF
--- a/library/src/main/java/com/afollestad/materialdialogs/AlertDialogWrapper.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/AlertDialogWrapper.java
@@ -233,6 +233,7 @@ public class AlertDialogWrapper {
                 selectedIndicesArr = selectedIndices.toArray(new Integer[selectedIndices.size()]);
             }
 
+            builder.alwaysCallMultiChoiceCallback();
             builder.itemsCallbackMultiChoice(selectedIndicesArr, new MaterialDialog.ListCallbackMulti() {
                 @Override
                 public void onSelection(MaterialDialog dialog, Integer[] which, CharSequence[] text) {

--- a/library/src/main/java/com/afollestad/materialdialogs/AlertDialogWrapper.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/AlertDialogWrapper.java
@@ -220,6 +220,11 @@ public class AlertDialogWrapper {
             return this;
         }
 
+        public Builder alwaysCallMultiChoiceCallback() {
+            builder.alwaysCallMultiChoiceCallback();
+            return this;
+        }
+
         private void setUpMultiChoiceCallback(@Nullable final boolean[] checkedItems, final DialogInterface.OnMultiChoiceClickListener listener) {
             Integer selectedIndicesArr[] = null;
             /* Convert old style array of booleans-per-index to new list of indices */
@@ -233,7 +238,6 @@ public class AlertDialogWrapper {
                 selectedIndicesArr = selectedIndices.toArray(new Integer[selectedIndices.size()]);
             }
 
-            builder.alwaysCallMultiChoiceCallback();
             builder.itemsCallbackMultiChoice(selectedIndicesArr, new MaterialDialog.ListCallbackMulti() {
                 @Override
                 public void onSelection(MaterialDialog dialog, Integer[] which, CharSequence[] text) {


### PR DESCRIPTION
As requested in #303 

This pull requests add the option, as the stock AlertDialog calls the callback everytime a choice is clicked. However, if this behaviour was enabled by default, it would alter how the AlertDialogWrapper.Builder works for existing users and may be confusing. So I did it this way instead.