### PR TITLE
Add RIGHT and LEFT gravities to support RTL in old SDKs

### DIFF
--- a/library/src/main/java/com/afollestad/materialdialogs/GravityEnum.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/GravityEnum.java
@@ -1,5 +1,5 @@
 package com.afollestad.materialdialogs;
 
 public enum GravityEnum {
-    START, CENTER, END
+    START, CENTER, END, RIGHT, LEFT
 }

--- a/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -359,6 +359,10 @@ public class MaterialDialog extends DialogBase implements View.OnClickListener, 
                 return Gravity.CENTER_HORIZONTAL;
             case END:
                 return Gravity.END;
+            case RIGHT:
+                return Gravity.RIGHT;
+            case LEFT:
+                return Gravity.LEFT;
             default:
                 return Gravity.START;
         }


### PR DESCRIPTION
In RTL languages (such as Persian, Arabic, etc.) on old SDKs, the `Gravity` of a `TextView` should be forced to `RIGHT`. If you used `END` gravity for RTL, in old SDKs the text would be on right, whereas in new SDKs (supporting RTL), the text would be on left.
So `LEFT` and `RIGHT` were added to `GravityEnum` class and `gravityIntToGravity` method of `MaterialDialog` class. Now `LEFT` and `RIGHT` could be passed to `titleGravity` and `contentGravity` methods of `MaterialDialog.Builder` subclass.