### PR TITLE
Fix for button backgrounds (transparency added)

### DIFF
--- a/library/src/main/res/drawable-v21/md_btn_selector_ripple.xml
+++ b/library/src/main/res/drawable-v21/md_btn_selector_ripple.xml
@@ -1,6 +1,7 @@
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
     android:color="?android:colorControlHighlight">
 
-    <item android:drawable="@drawable/md_btn_selector" />
+    <item android:id="@android:id/mask"
+        android:drawable="@drawable/md_btn_shape"/>
 
 </ripple>

--- a/library/src/main/res/drawable-v21/md_btn_selector_ripple_dark.xml
+++ b/library/src/main/res/drawable-v21/md_btn_selector_ripple_dark.xml
@@ -1,6 +1,7 @@
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
     android:color="?android:colorControlHighlight">
 
-    <item android:drawable="@drawable/md_btn_selector_dark" />
+    <item android:id="@android:id/mask"
+        android:drawable="@drawable/md_btn_shape"/>
 
 </ripple>

--- a/library/src/main/res/drawable-v21/md_btn_shape.xml
+++ b/library/src/main/res/drawable-v21/md_btn_shape.xml
@@ -4,10 +4,9 @@
     android:insetLeft="@dimen/md_button_inset_horizontal"
     android:insetRight="@dimen/md_button_inset_horizontal"
     android:insetTop="@dimen/md_button_inset_vertical">
-    <shape xmlns:android="http://schemas.android.com/apk/res/android"
-        android:shape="rectangle">
+    <shape android:shape="rectangle">
         <corners android:radius="@dimen/md_action_corner_radius" />
-        <solid android:color="@color/md_btn_selected_dark" />
+        <solid android:color="?android:colorButtonNormal" />
         <padding
             android:bottom="@dimen/md_button_padding_vertical"
             android:left="@dimen/md_button_padding_horizontal"

--- a/library/src/main/res/drawable/md_btn_selected.xml
+++ b/library/src/main/res/drawable/md_btn_selected.xml
@@ -7,7 +7,7 @@
     <shape xmlns:android="http://schemas.android.com/apk/res/android"
         android:shape="rectangle">
         <corners android:radius="@dimen/md_action_corner_radius" />
-        <solid android:color="#E5E5E5" />
+        <solid android:color="@color/md_btn_selected" />
         <padding
             android:bottom="@dimen/md_button_padding_vertical"
             android:left="@dimen/md_button_padding_horizontal"

--- a/library/src/main/res/drawable/md_item_selected.xml
+++ b/library/src/main/res/drawable/md_item_selected.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="#D5D5D5" />
+    <solid android:color="@color/md_btn_selected" />
 </shape>

--- a/library/src/main/res/drawable/md_item_selected_dark.xml
+++ b/library/src/main/res/drawable/md_item_selected_dark.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="#404040" />
+    <solid android:color="@color/md_btn_selected_dark" />
 </shape>

--- a/library/src/main/res/values-v11/styles.xml
+++ b/library/src/main/res/values-v11/styles.xml
@@ -14,8 +14,8 @@
 
     <style name="MD_Dark" parent="android:Theme.Holo.Dialog">
         <item name="md_divider">@color/md_divider_white</item>
-        <item name="md_list_selector">@drawable/md_selector</item>
-        <item name="md_btn_stacked_selector">@drawable/md_selector</item>
+        <item name="md_list_selector">@drawable/md_selector_dark</item>
+        <item name="md_btn_stacked_selector">@drawable/md_selector_dark</item>
         <item name="md_btn_positive_selector">@drawable/md_btn_selector_dark</item>
         <item name="md_btn_neutral_selector">@drawable/md_btn_selector_dark</item>
         <item name="md_btn_negative_selector">@drawable/md_btn_selector_dark</item>

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -8,6 +8,9 @@
     <!--<color name="button_light">#3C3C3D</color>-->
     <!--<color name="button_dark">#FFFFFF</color>-->
 
+    <color name="md_btn_selected">#33969696</color>
+    <color name="md_btn_selected_dark">#40CBCBCB</color>
+
     <color name="md_divider_black">#10000000</color>
     <color name="md_divider_white">#10FFFFFF</color>
 

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -11,8 +11,8 @@
 
     <style name="MD_Dark" parent="android:Theme.Dialog">
         <item name="md_divider">@color/md_divider_white</item>
-        <item name="md_list_selector">@drawable/md_selector</item>
-        <item name="md_btn_stacked_selector">@drawable/md_selector</item>
+        <item name="md_list_selector">@drawable/md_selector_dark</item>
+        <item name="md_btn_stacked_selector">@drawable/md_selector_dark</item>
         <item name="md_btn_positive_selector">@drawable/md_btn_selector_dark</item>
         <item name="md_btn_neutral_selector">@drawable/md_btn_selector_dark</item>
         <item name="md_btn_negative_selector">@drawable/md_btn_selector_dark</item>


### PR DESCRIPTION
Fixes #348 (Buttons have their own background)

1. I've added transparency to the button backgrounds on pre-Lollipop.
2. Fixed ripples to end up with correct color and mask on Lollipop.
3. Colors for light and dark selected drawables (also defined in colors.xml) was extracted from drawables from support lib.
4. In dark themes @drawable/md_selector was used instead of @drawable/md_selector_dark. I've changed that, please correct me if that was on purpose.

Greetings