### PR TITLE
Respect theme's textAllCaps setting

### DIFF
--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -40,7 +40,7 @@
     </style>
 
     <style name="MD_ActionButton.Text" tools:ignore="NewApi">
-        <item name="android:textAllCaps">true</item>
+        <item name="android:textAllCaps">?android:textAllCaps</item>
         <item name="android:textSize">@dimen/md_button_textsize</item>
         <item name="android:singleLine">true</item>
         <item name="android:layout_gravity">center_vertical</item>


### PR DESCRIPTION
Lollipop's alert dialogs respect the current theme's `android:textAllCaps` attribute. It would be great if these did too. I don't know if there is any other way to override this.
