### PR TITLE
Grant access to title and content TextViews

### DIFF
--- a/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -1547,6 +1547,20 @@ public class MaterialDialog extends DialogBase implements
     }
 
     /**
+     * Retrieves the text view containing the dialog title passed from the builder.
+     */
+    public final TextView getTitleTextView() {
+        return title;
+    }
+
+    /**
+     * Retrieves the text view containing the dialog content passed from the builder.
+     */
+    public final TextView getContentTextView() {
+        return content;
+    }
+
+    /**
      * Retrieves the custom view that was inflated or set to the MaterialDialog during building.
      *
      * @return The custom view that was passed into the Builder.


### PR DESCRIPTION
After switching to material-dialogs, I can no longer access the title or message content of any of my dialogs in my tests using Robolectric. `ShadowAlertDialog.getLatestAlertDialog()` works for retrieving the dialog if it's shown, but none of the `shadowOf()` accessors are able to return anything for reasons beyond my comprehension at this time. However, since I'm able to access the `customView` or `listView`, and all of the action buttons, it doesn't seem unreasonable to be able to access the title and content views as well.