### PR TITLE
Refactor padding to be more efficient

### DIFF
--- a/library/src/main/java/com/afollestad/materialdialogs/GravityEnum.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/GravityEnum.java
@@ -1,5 +1,34 @@
 package com.afollestad.materialdialogs;
 
+import android.os.Build;
+import android.view.Gravity;
+import android.view.View;
+
 public enum GravityEnum {
-    START, CENTER, END
+    START, CENTER, END;
+
+    private static final boolean HAS_RTL = Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1;
+    public int getGravityInt() {
+        switch (this) {
+            case START:
+                return HAS_RTL ? Gravity.START : Gravity.LEFT;
+            case CENTER:
+                return Gravity.CENTER_HORIZONTAL;
+            case END:
+                return HAS_RTL ? Gravity.END : Gravity.RIGHT;
+            default:
+                throw new IllegalStateException("Invalid gravity constant");
+        }
+    }
+
+    public int getTextAlignment() {
+        switch (this) {
+            case CENTER:
+                return View.TEXT_ALIGNMENT_CENTER;
+            case END:
+                return View.TEXT_ALIGNMENT_VIEW_END;
+            default:
+                return View.TEXT_ALIGNMENT_VIEW_START;
+        }
+    }
 }

--- a/library/src/main/java/com/afollestad/materialdialogs/MaterialDialogAdapter.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/MaterialDialogAdapter.java
@@ -79,7 +79,7 @@ class MaterialDialogAdapter extends ArrayAdapter<CharSequence> {
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
     private void setupGravity(ViewGroup view) {
         final LinearLayout itemRoot = (LinearLayout) view;
-        final int gravityInt = MaterialDialog.gravityEnumToGravity(itemGravity);
+        final int gravityInt = itemGravity.getGravityInt();
         itemRoot.setGravity(gravityInt | Gravity.CENTER_VERTICAL);
 
         if (view.getChildCount() == 2) {

--- a/library/src/main/java/com/afollestad/materialdialogs/base/DialogBase.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/base/DialogBase.java
@@ -3,8 +3,6 @@ package com.afollestad.materialdialogs.base;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.graphics.drawable.Drawable;
-import android.os.Build;
 import android.os.Message;
 import android.view.View;
 import android.view.ViewGroup;
@@ -13,10 +11,6 @@ import android.view.ViewGroup;
  * @author Aidan Follestad (afollestad)
  */
 public class DialogBase extends AlertDialog implements DialogInterface.OnShowListener {
-
-    protected final static String POSITIVE = "POSITIVE";
-    protected final static String NEGATIVE = "NEGATIVE";
-    protected final static String NEUTRAL = "NEUTRAL";
     private OnShowListener mShowListener;
 
     protected DialogBase(Context context) {
@@ -102,12 +96,4 @@ public class DialogBase extends AlertDialog implements DialogInterface.OnShowLis
             mShowListener.onShow(dialog);
     }
 
-    protected void setBackgroundCompat(View view, Drawable d) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
-            //noinspection deprecation
-            view.setBackgroundDrawable(d);
-        } else {
-            view.setBackground(d);
-        }
-    }
 }

--- a/library/src/main/java/com/afollestad/materialdialogs/internal/MDButton.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/internal/MDButton.java
@@ -1,0 +1,100 @@
+package com.afollestad.materialdialogs.internal;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.support.v7.internal.text.AllCapsTransformationMethod;
+import android.util.AttributeSet;
+import android.view.Gravity;
+import android.widget.TextView;
+
+import com.afollestad.materialdialogs.GravityEnum;
+import com.afollestad.materialdialogs.R;
+import com.afollestad.materialdialogs.util.DialogUtils;
+
+/**
+ * @author Kevin Barry (teslacoil) 4/02/2015
+ */
+public class MDButton extends TextView {
+
+    private boolean mStacked = false;
+    private GravityEnum mStackedGravity;
+
+    private int mStackedEndPadding;
+    private Drawable mStackedBackground;
+    private Drawable mDefaultBackground;
+
+    public MDButton(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init(context, attrs, 0, 0);
+    }
+
+    public MDButton(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init(context, attrs, defStyleAttr, 0);
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public MDButton(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        init(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+    private void init(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        mStackedEndPadding = context.getResources()
+                .getDimensionPixelSize(R.dimen.md_dialog_frame_margin);
+        mStackedGravity = GravityEnum.END;
+    }
+
+    /**
+     * Set if the button should be displayed in stacked mode.
+     * This should only be called from MDRootLayout's onMeasure, and we must be measured
+     * after calling this.
+     */
+    /* package */ void setStacked(boolean stacked, boolean force) {
+        if (mStacked != stacked || force) {
+
+            setGravity(stacked ? (Gravity.CENTER_VERTICAL | mStackedGravity.getGravityInt()) : Gravity.CENTER);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                //noinspection ResourceType
+                setTextAlignment(stacked ? mStackedGravity.getTextAlignment() : TEXT_ALIGNMENT_CENTER);
+            }
+
+            DialogUtils.setBackgroundCompat(this, stacked ? mStackedBackground : mDefaultBackground);
+            if (stacked) {
+                setPadding(mStackedEndPadding, getPaddingTop(), mStackedEndPadding, getPaddingBottom());
+            } /* Else the padding was properly reset by the drawable */
+
+        }
+    }
+
+    public void setStackedGravity(GravityEnum gravity) {
+        mStackedGravity = gravity;
+    }
+
+    public void setStackedSelector(Drawable d) {
+        mStackedBackground = d;
+        if (mStacked)
+            setStacked(mStacked, true);
+    }
+
+    public void setDefaultSelector(Drawable d) {
+        mDefaultBackground = d;
+        if (!mStacked)
+            setStacked(mStacked, true);
+    }
+
+    public void setAllCapsCompat(boolean allCaps) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+            setAllCaps(allCaps);
+        } else {
+            if (allCaps) {
+                setTransformationMethod(new AllCapsTransformationMethod(getContext()));
+            } else {
+                setTransformationMethod(null);
+            }
+        }
+    }
+
+}

--- a/library/src/main/java/com/afollestad/materialdialogs/internal/MDRootLayout.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/internal/MDRootLayout.java
@@ -1,0 +1,442 @@
+package com.afollestad.materialdialogs.internal;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.os.Build;
+import android.support.annotation.Nullable;
+import android.support.v7.widget.RecyclerView;
+import android.util.AttributeSet;
+import android.util.Log;
+import android.view.View;
+import android.view.ViewGroup;
+import android.webkit.WebView;
+import android.widget.AdapterView;
+import android.widget.ScrollView;
+
+import com.afollestad.materialdialogs.GravityEnum;
+import com.afollestad.materialdialogs.R;
+import com.afollestad.materialdialogs.util.RecyclerUtil;
+
+/**
+ * @author Kevin Barry (teslacoil) 4/02/2015
+ *
+ * This is the top level view for all MaterialDialogs
+ * It handles the layout of:
+ *  titleFrame (md_stub_titleframe)
+ *  content (text, custom view, listview, etc)
+ *  buttonDefault... (either stacked or horizontal)
+ */
+public class MDRootLayout extends ViewGroup {
+    private static final String TAG = "MD.RootView";
+
+    private View mTitleBar;
+    private View mContent;
+
+    private static final int INDEX_NEUTRAL = 0;
+    private static final int INDEX_NEGATIVE = 1;
+    private static final int INDEX_POSITIVE = 2;
+    private boolean mDrawTopDivider = false;
+    private boolean mDrawBottomDivider = false;
+    private MDButton[] mButtons = new MDButton[3];
+    private boolean mForceStack = false;
+    private boolean mIsStacked = false;
+    private boolean mUseFullPadding = true;
+
+    private int mNoTitlePaddingFull;
+    private int mButtonPaddingFull;
+    private int mButtonBarHeight;
+
+    private GravityEnum mButtonGravity = GravityEnum.START;
+
+    /* Margin from dialog frame to first button */
+    private int mButtonHorizontalEdgeMargin;
+
+    private Paint mDividerPaint;
+
+    public MDRootLayout(Context context) {
+        super(context);
+        init(context, null, 0);
+    }
+
+    public MDRootLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init(context, attrs, 0);
+    }
+
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    public MDRootLayout(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init(context, attrs, defStyleAttr);
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public MDRootLayout(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        init(context, attrs, defStyleAttr);
+    }
+
+    private void init(Context context, AttributeSet attrs, int defStyleAttr) {
+        Resources r = context.getResources();
+        mNoTitlePaddingFull = r.getDimensionPixelSize(R.dimen.md_notitle_vertical_padding);
+        mButtonPaddingFull = r.getDimensionPixelSize(R.dimen.md_button_frame_vertical_padding);
+
+        mButtonHorizontalEdgeMargin = r.getDimensionPixelSize(R.dimen.md_button_padding_frame_side);
+        mButtonBarHeight = r.getDimensionPixelSize(R.dimen.md_button_height);
+
+        mDividerPaint = new Paint();
+        mDividerPaint.setStrokeWidth(r.getDimensionPixelSize(R.dimen.md_divider_height));
+        mDividerPaint.setStyle(Paint.Style.STROKE);
+        setWillNotDraw(false);
+    }
+
+    @Override
+    public void onFinishInflate() {
+        super.onFinishInflate();
+
+        for (int i = 0; i < getChildCount(); i++) {
+            View v = getChildAt(i);
+            if (v.getId() == R.id.titleFrame) {
+                mTitleBar = v;
+            } else if (v.getId() == R.id.buttonDefaultNeutral) {
+                mButtons[INDEX_NEUTRAL] = (MDButton) v;
+            } else if (v.getId() == R.id.buttonDefaultNegative) {
+                mButtons[INDEX_NEGATIVE] = (MDButton) v;
+            } else if (v.getId() == R.id.buttonDefaultPositive) {
+                mButtons[INDEX_POSITIVE] = (MDButton) v;
+            } else {
+                mContent = v;
+            }
+        }
+    }
+
+    @Override
+    public void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        int width = MeasureSpec.getSize(widthMeasureSpec);
+        int height = MeasureSpec.getSize(heightMeasureSpec);
+
+        mUseFullPadding = true;
+        boolean hasButtons = false;
+
+        final boolean stacked;
+        if (!mForceStack) {
+            int buttonsWidth = 0;
+            for (int i = 0; i < mButtons.length; i++) {
+                MDButton button = mButtons[i];
+                if (button != null && button.getVisibility() != View.GONE) {
+                    button.setStacked(false, false);
+                    measureChild(button, widthMeasureSpec, heightMeasureSpec);
+                    buttonsWidth += button.getMeasuredWidth();
+                    hasButtons = true;
+                }
+            }
+            Log.v(TAG, "buttonWidth " + buttonsWidth + " " + mButtonBarHeight);
+
+            int buttonBarPadding = getContext().getResources()
+                    .getDimensionPixelSize(R.dimen.md_neutral_button_margin);
+            final int buttonFrameWidth = width - 2 * buttonBarPadding;
+            stacked = buttonsWidth > buttonFrameWidth;
+        } else {
+            stacked = mForceStack;
+        }
+
+        int stackedHeight = 0;
+        mIsStacked = stacked;
+        if (stacked) {
+            for (int i = 0; i < mButtons.length; i++) {
+                MDButton button = mButtons[i];
+                if (button != null && button.getVisibility() != View.GONE) {
+                    button.setStacked(true, false);
+                    measureChild(button, widthMeasureSpec, heightMeasureSpec);
+                    stackedHeight += button.getMeasuredHeight();
+                }
+            }
+        }
+
+        int availableHeight = height;
+        int fullPadding = 0;
+        int minPadding = 0;
+        if (hasButtons) {
+            if (mIsStacked) {
+                availableHeight -= stackedHeight;
+                fullPadding += 2*mButtonPaddingFull;
+                minPadding += 2*mButtonPaddingFull;
+            } else {
+                availableHeight -= mButtonBarHeight;
+                fullPadding += 2 * mButtonPaddingFull;
+                /* No minPadding */
+            }
+        } else {
+            /* Content has 8dp, we add 16dp and get 24dp, the frame margin */
+            fullPadding += 2*mButtonPaddingFull;
+        }
+
+        if (mTitleBar != null && mTitleBar.getVisibility() != View.GONE) {
+            mTitleBar.measure(MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+                    MeasureSpec.UNSPECIFIED);
+            availableHeight -= mTitleBar.getMeasuredHeight();
+        } else {
+            fullPadding += mNoTitlePaddingFull;
+        }
+
+        if (mContent != null && mContent.getVisibility() != View.GONE) {
+            mContent.measure(MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+                    MeasureSpec.makeMeasureSpec(availableHeight - minPadding, MeasureSpec.AT_MOST));
+
+            if (mContent.getMeasuredHeight() < availableHeight - fullPadding) {
+                mUseFullPadding = true;
+                availableHeight -= mContent.getMeasuredHeight() + fullPadding;
+            } else {
+                mUseFullPadding = false;
+                availableHeight = 0;
+                mDrawTopDivider =  mTitleBar != null && mTitleBar.getVisibility() != View.GONE &&
+                        canViewOrChildScroll(mContent, false);
+                mDrawBottomDivider =  hasButtons &&
+                        canViewOrChildScroll(mContent, true);
+            }
+
+        }
+
+        setMeasuredDimension(width, height - availableHeight);
+    }
+
+    @Override
+    public void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+
+        if (mContent != null) {
+            if (mDrawTopDivider) {
+                int y = mContent.getTop();
+                canvas.drawLine(0, y, getMeasuredWidth(), y, mDividerPaint);
+            }
+
+            if (mDrawBottomDivider) {
+                int y = mContent.getBottom();
+                canvas.drawLine(0, y, getMeasuredWidth(), y, mDividerPaint);
+            }
+        }
+    }
+
+    @Override
+    protected void onLayout(boolean changed, final int l, int t, final int r, int b) {
+        if (mTitleBar != null && mTitleBar.getVisibility() != View.GONE) {
+            int height = mTitleBar.getMeasuredHeight();
+            mTitleBar.layout(l, t, r, t + height);
+            t += height;
+        } else if (mUseFullPadding) {
+            t += mNoTitlePaddingFull;
+        }
+
+        if (mContent != null && mContent.getVisibility() != View.GONE) {
+            mContent.layout(l, t, r, t + mContent.getMeasuredHeight());
+        }
+
+        if (mIsStacked) {
+            b -= mButtonPaddingFull;
+            for (int i = 0; i < mButtons.length; i++) {
+                if (mButtons[i] != null && mButtons[i].getVisibility() != View.GONE) {
+                    mButtons[i].layout(l, b - mButtons[i].getMeasuredHeight(), r, b);
+                    b -= mButtons[i].getMeasuredHeight();
+                }
+            }
+        } else {
+            int barTop;
+            int barBottom = b;
+            if (mUseFullPadding) {
+                barBottom -= mButtonPaddingFull;
+            }
+            barTop = barBottom - mButtonBarHeight;
+            /* START:
+               Neutral   Negative  Positive
+
+               CENTER:
+               Negative  Neutral   Positive
+
+               END:
+               Positive  Negative  Neutral
+
+               (With no Positive, Negative takes it's place except for CENTER)
+             */
+            int offset = mButtonHorizontalEdgeMargin;
+
+            /* Used with CENTER gravity */
+            int neutralLeft = -1;
+            int neutralRight = -1;
+
+            if (mButtons[INDEX_POSITIVE] != null && mButtons[INDEX_POSITIVE].getVisibility() != View.GONE) {
+                int bl, br;
+
+                if (mButtonGravity == GravityEnum.END) {
+                    bl = l + offset;
+                    br = bl + mButtons[INDEX_POSITIVE].getMeasuredWidth();
+                } else { /* START || CENTER */
+                    br = r - offset;
+                    bl = br - mButtons[INDEX_POSITIVE].getMeasuredWidth();
+                    neutralRight = bl;
+                }
+
+                mButtons[INDEX_POSITIVE].layout(bl, barTop, br, barBottom);
+
+                offset += mButtons[INDEX_POSITIVE].getMeasuredWidth();
+            }
+
+            if (mButtons[INDEX_NEGATIVE] != null && mButtons[INDEX_NEGATIVE].getVisibility() != View.GONE) {
+
+                int bl, br;
+
+                if (mButtonGravity == GravityEnum.END) {
+                    bl = l + offset;
+                    br = bl + mButtons[INDEX_NEGATIVE].getMeasuredWidth();
+                } else if (mButtonGravity == GravityEnum.START) {
+                    br = r - offset;
+                    bl = br - mButtons[INDEX_NEGATIVE].getMeasuredWidth();
+                } else { /* CENTER */
+                    bl = l + mButtonHorizontalEdgeMargin;
+                    br = bl + mButtons[INDEX_NEGATIVE].getMeasuredWidth();
+                    neutralLeft = br;
+                }
+
+                mButtons[INDEX_NEGATIVE].layout(bl, barTop, br, barBottom);
+            }
+
+            if (mButtons[INDEX_NEUTRAL] != null && mButtons[INDEX_NEUTRAL].getVisibility() != View.GONE) {
+                int bl, br;
+                if (mButtonGravity == GravityEnum.END) {
+                    br = r - mButtonHorizontalEdgeMargin;
+                    bl = br - mButtons[INDEX_NEUTRAL].getMeasuredWidth();
+                } else if (mButtonGravity == GravityEnum.START) {
+                    bl = l + mButtonHorizontalEdgeMargin;
+                    br = bl + mButtons[INDEX_NEUTRAL].getMeasuredWidth();
+                } else { /* CENTER */
+                    if (neutralLeft == -1 && neutralRight != -1) {
+                        neutralLeft = neutralRight - mButtons[INDEX_NEUTRAL].getMeasuredWidth();
+                    } else if (neutralRight == -1 && neutralLeft != -1) {
+                        neutralRight = neutralLeft + mButtons[INDEX_NEUTRAL].getMeasuredWidth();
+                    } else if (neutralRight == -1 && neutralLeft == -1) {
+                        neutralLeft = (r - l)/2 - mButtons[INDEX_NEUTRAL].getMeasuredWidth()/2;
+                        neutralRight = neutralLeft + mButtons[INDEX_NEUTRAL].getMeasuredWidth();
+                    }
+                    bl = neutralLeft;
+                    br = neutralRight;
+                }
+
+                mButtons[INDEX_NEUTRAL].layout(bl, barTop, br, barBottom);
+            }
+        }
+    }
+
+    public void setForceStack(boolean forceStack) {
+        mForceStack = forceStack;
+        invalidate();
+    }
+
+    public void setDividerColor(int color) {
+        mDividerPaint.setColor(color);
+        invalidate();
+    }
+
+    public void setButtonGravity(GravityEnum gravity) {
+        mButtonGravity = gravity;
+    }
+
+    public void setButtonStackedGravity(GravityEnum gravity) {
+        for (int i = 0; i < mButtons.length; i++) {
+            if (mButtons[i] != null)
+                mButtons[i].setStackedGravity(gravity);
+        }
+    }
+
+    private static boolean canViewOrChildScroll(View view, boolean atBottom) {
+        if (view == null)
+            return false;
+        if (view instanceof ScrollView) {
+            return canScrollViewScroll((ScrollView) view);
+        } else if (view instanceof AdapterView) {
+            return canAdapterViewScroll((AdapterView) view);
+        } else if (view instanceof WebView) {
+            return canWebViewScroll((WebView) view);
+        } else if (view instanceof RecyclerView) {
+            return RecyclerUtil.canRecyclerViewScroll(view);
+        } else if (view instanceof ViewGroup) {
+            if (atBottom) {
+                return canViewOrChildScroll(getBottomView((ViewGroup) view), true);
+            } else {
+                return canViewOrChildScroll(getTopView((ViewGroup) view), false);
+            }
+        } else {
+            return false;
+        }
+    }
+
+    private static boolean canScrollViewScroll(ScrollView sv) {
+        if (sv.getChildCount() == 0)
+            return false;
+        final int childHeight = sv.getChildAt(0).getMeasuredHeight();
+        return sv.getMeasuredHeight() - sv.getPaddingTop() - sv.getPaddingBottom() < childHeight;
+    }
+
+    private static boolean canWebViewScroll(WebView view) {
+        return view.getMeasuredHeight() > view.getContentHeight();
+    }
+
+    private static boolean canAdapterViewScroll(AdapterView lv) {
+        /* Force it to layout it's children */
+        if (lv.getLastVisiblePosition() == -1)
+            return false;
+
+        /* We can scroll if the first or last item is not visible */
+        boolean firstItemVisible = lv.getFirstVisiblePosition() == 0;
+        boolean lastItemVisible = lv.getLastVisiblePosition() == lv.getCount() - 1;
+
+        if (firstItemVisible && lastItemVisible) {
+            /* Or the first item's top is above or own top */
+            if (lv.getChildAt(0).getTop() < lv.getPaddingTop())
+                return true;
+
+            /* or the last item's bottom is beyond our own bottom */
+            return lv.getChildAt(lv.getChildCount() - 1).getBottom() >
+                    lv.getHeight() - lv.getPaddingBottom();
+        }
+
+        return true;
+    }
+
+    /**
+     * Find the view touching the bottom of this ViewGroup. Non visible children are ignored,
+     * however getChildDrawingOrder is not taking into account for simplicity and because it behaves
+     * inconsistently across platform versions.
+     *
+     * @return View touching the bottom of this viewgroup or null
+     */
+    @Nullable
+    private static View getBottomView(ViewGroup viewGroup) {
+        if (viewGroup == null)
+            return null;
+        View bottomView = null;
+        for (int i = viewGroup.getChildCount() - 1; i >= 0; i--) {
+            View child = viewGroup.getChildAt(i);
+            if (child.getVisibility() == View.VISIBLE && child.getBottom() == viewGroup.getMeasuredHeight()) {
+                bottomView = child;
+                break;
+            }
+        }
+        return bottomView;
+    }
+
+    @Nullable
+    private static View getTopView(ViewGroup viewGroup) {
+        if (viewGroup == null)
+            return null;
+        View topView = null;
+        for (int i = viewGroup.getChildCount() - 1; i >= 0; i--) {
+            View child = viewGroup.getChildAt(i);
+            if (child.getVisibility() == View.VISIBLE && child.getTop() == 0) {
+                topView = child;
+                break;
+            }
+        }
+        return topView;
+    }
+}

--- a/library/src/main/java/com/afollestad/materialdialogs/util/DialogUtils.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/util/DialogUtils.java
@@ -4,7 +4,9 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.support.annotation.AttrRes;
+import android.view.View;
 
 import com.afollestad.materialdialogs.GravityEnum;
 
@@ -106,5 +108,14 @@ public class DialogUtils {
     public static boolean isColorDark(int color) {
         double darkness = 1 - (0.299 * Color.red(color) + 0.587 * Color.green(color) + 0.114 * Color.blue(color)) / 255;
         return darkness >= 0.5;
+    }
+
+    public static void setBackgroundCompat(View view, Drawable d) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
+            //noinspection deprecation
+            view.setBackgroundDrawable(d);
+        } else {
+            view.setBackground(d);
+        }
     }
 }

--- a/library/src/main/res/layout/md_dialog_basic.xml
+++ b/library/src/main/res/layout/md_dialog_basic.xml
@@ -1,46 +1,31 @@
-<LinearLayout
+<com.afollestad.materialdialogs.internal.MDRootLayout
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <LinearLayout
-        android:id="@+id/mainFrame"
-        android:orientation="vertical"
+    <include layout="@layout/md_stub_titleframe" />
+
+    <ScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1">
+        android:layout_height="wrap_content"
+        android:clipToPadding="false"
+        android:paddingTop="@dimen/md_content_padding_top"
+        android:paddingBottom="@dimen/md_content_padding_bottom">
 
-        <include layout="@layout/md_stub_titleframe" />
-
-        <View
-            android:id="@+id/titleBarDivider"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginTop="@dimen/md_content_vertical_padding"
-            android:layout_marginBottom="-1dp"
-            android:visibility="gone" />
-
-        <ScrollView
-            android:id="@+id/contentScrollView"
+        <TextView
+            android:id="@+id/content"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:visibility="gone"
-            android:clipToPadding="false"
-            android:paddingBottom="@dimen/md_content_vertical_padding">
+            android:paddingLeft="@dimen/md_dialog_frame_margin"
+            android:paddingRight="@dimen/md_dialog_frame_margin"
+            android:textSize="@dimen/md_content_textsize"
+            tools:text="Content" />
 
-            <TextView
-                android:id="@+id/content"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:textSize="@dimen/md_content_textsize"
-                tools:text="Content" />
-
-        </ScrollView>
-
-    </LinearLayout>
+    </ScrollView>
 
     <include layout="@layout/md_stub_actionbuttons" />
 
-</LinearLayout>
+</com.afollestad.materialdialogs.internal.MDRootLayout>

--- a/library/src/main/res/layout/md_dialog_custom.xml
+++ b/library/src/main/res/layout/md_dialog_custom.xml
@@ -1,33 +1,16 @@
-<LinearLayout
+<com.afollestad.materialdialogs.internal.MDRootLayout
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <LinearLayout
-        android:id="@+id/mainFrame"
-        android:orientation="vertical"
+    <include layout="@layout/md_stub_titleframe" />
+
+    <FrameLayout
+        android:id="@+id/customViewFrame"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1">
-
-        <include layout="@layout/md_stub_titleframe" />
-
-        <View
-            android:id="@+id/titleBarDivider"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginTop="@dimen/md_content_vertical_padding"
-            android:layout_marginBottom="-1dp"
-            android:visibility="gone" />
-
-        <FrameLayout
-            android:id="@+id/customViewFrame"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-
-    </LinearLayout>
+        android:layout_height="wrap_content" />
 
     <include layout="@layout/md_stub_actionbuttons" />
 
-</LinearLayout>
+</com.afollestad.materialdialogs.internal.MDRootLayout>

--- a/library/src/main/res/layout/md_dialog_list.xml
+++ b/library/src/main/res/layout/md_dialog_list.xml
@@ -1,39 +1,31 @@
-<LinearLayout
+<com.afollestad.materialdialogs.internal.MDRootLayout
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <include layout="@layout/md_stub_titleframe" />
+
     <LinearLayout
-        android:id="@+id/mainFrame"
         android:orientation="vertical"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1">
-
-        <include layout="@layout/md_stub_titleframe" />
-
-        <View
-            android:id="@+id/titleBarDivider"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginTop="@dimen/md_content_vertical_padding"
-            android:layout_marginBottom="-1dp"
-            android:visibility="gone" />
+        android:layout_height="match_parent">
 
         <ScrollView
             android:id="@+id/contentScrollView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:visibility="gone"
-            android:clipToPadding="false"
-            android:paddingBottom="@dimen/md_content_vertical_padding">
+            android:clipToPadding="false">
 
             <TextView
                 android:id="@+id/content"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:paddingLeft="@dimen/md_dialog_frame_margin"
+                android:paddingTop="@dimen/md_content_padding_top"
+                android:paddingRight="@dimen/md_dialog_frame_margin"
+                android:paddingBottom="@dimen/md_content_padding_bottom"
                 android:textSize="@dimen/md_content_textsize"
                 tools:text="Content" />
 
@@ -44,7 +36,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <!-- Top padding cancelled out in code if there's a title -->
             <ListView
                 android:id="@+id/contentListView"
                 android:layout_width="match_parent"
@@ -53,8 +44,8 @@
                 android:divider="@null"
                 android:dividerHeight="0dp"
                 android:clipToPadding="false"
-                android:paddingTop="12dp"
-                android:paddingBottom="12dp" />
+                android:paddingTop="@dimen/md_content_padding_top"
+                android:paddingBottom="@dimen/md_content_padding_bottom" />
 
         </FrameLayout>
 
@@ -62,4 +53,4 @@
 
     <include layout="@layout/md_stub_actionbuttons" />
 
-</LinearLayout>
+</com.afollestad.materialdialogs.internal.MDRootLayout>

--- a/library/src/main/res/layout/md_dialog_progress.xml
+++ b/library/src/main/res/layout/md_dialog_progress.xml
@@ -1,26 +1,21 @@
-<LinearLayout
+<com.afollestad.materialdialogs.internal.MDRootLayout
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <include layout="@layout/md_stub_titleframe" />
+
     <LinearLayout
-        android:id="@+id/mainFrame"
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:paddingBottom="@dimen/md_title_frame_margin_bottom">
-
-        <include layout="@layout/md_stub_titleframe" />
-
-        <View
-            android:id="@+id/titleBarDivider"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginTop="@dimen/md_content_vertical_padding"
-            android:layout_marginBottom="-1dp"
-            android:visibility="gone" />
+        android:paddingLeft="@dimen/md_dialog_frame_margin"
+        android:paddingRight="@dimen/md_dialog_frame_margin"
+        android:paddingTop="@dimen/md_content_padding_top"
+        android:paddingBottom="@dimen/md_content_padding_bottom"
+        >
 
         <include layout="@layout/md_stub_progress" />
 
@@ -28,4 +23,4 @@
 
     <include layout="@layout/md_stub_actionbuttons" />
 
-</LinearLayout>
+</com.afollestad.materialdialogs.internal.MDRootLayout>

--- a/library/src/main/res/layout/md_dialog_progress_indeterminate.xml
+++ b/library/src/main/res/layout/md_dialog_progress_indeterminate.xml
@@ -1,31 +1,13 @@
-<LinearLayout
+<com.afollestad.materialdialogs.internal.MDRootLayout
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <LinearLayout
-        android:id="@+id/mainFrame"
-        android:orientation="vertical"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:paddingBottom="@dimen/md_dialog_frame_margin">
+    <include layout="@layout/md_stub_titleframe" />
 
-        <include layout="@layout/md_stub_titleframe" />
-
-        <View
-            android:id="@+id/titleBarDivider"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginTop="@dimen/md_content_vertical_padding"
-            android:layout_marginBottom="-1dp"
-            android:visibility="gone" />
-
-        <include layout="@layout/md_stub_progress_indeterminate" />
-
-    </LinearLayout>
+    <include layout="@layout/md_stub_progress_indeterminate" />
 
     <include layout="@layout/md_stub_actionbuttons" />
 
-</LinearLayout>
+</com.afollestad.materialdialogs.internal.MDRootLayout>

--- a/library/src/main/res/layout/md_stub_actionbuttons.xml
+++ b/library/src/main/res/layout/md_stub_actionbuttons.xml
@@ -1,111 +1,27 @@
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <View
-        android:id="@+id/buttonBarDivider"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:layout_marginTop="-1dp"
-        android:visibility="gone" />
 
-    <RelativeLayout
-        android:id="@+id/buttonDefaultFrame"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginLeft="@dimen/md_neutral_button_margin"
-        android:layout_marginStart="@dimen/md_neutral_button_margin"
-        android:layout_marginRight="@dimen/md_button_padding_frame_side"
-        android:layout_marginEnd="@dimen/md_button_padding_frame_side"
-        android:layout_marginBottom="@dimen/md_button_frame_vertical_padding">
+    <com.afollestad.materialdialogs.internal.MDButton
+        android:id="@+id/buttonDefaultNeutral"
+        style="@style/MD_ActionButton.Text"
+        tools:text="Neutral"
+        />
 
-        <FrameLayout
-            android:id="@+id/buttonDefaultNeutral"
-            style="@style/MD_ActionButton"
-            tools:layout_alignParentLeft="true"
-            tools:layout_alignParentStart="true">
+    <com.afollestad.materialdialogs.internal.MDButton
+        android:id="@+id/buttonDefaultNegative"
+        style="@style/MD_ActionButton.Text"
+        tools:layout_alignParentLeft="true"
+        tools:layout_alignParentStart="true"
+        tools:text="Negative"
+        />
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                tools:text="Neutral"
-                style="@style/MD_ActionButton.Text" />
-
-        </FrameLayout>
-
-        <FrameLayout
-            android:id="@+id/buttonDefaultNegative"
-            style="@style/MD_ActionButton"
-            tools:toLeftOf="@+id/buttonDefaultPositive"
-            tools:toStartOf="@+id/buttonDefaultPositive">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                tools:text="Negative"
-                style="@style/MD_ActionButton.Text" />
-
-        </FrameLayout>
-
-        <FrameLayout
-            android:id="@+id/buttonDefaultPositive"
-            style="@style/MD_ActionButton"
-            tools:layout_alignParentRight="true"
-            tools:layout_alignParentEnd="true">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                tools:text="Positive"
-                style="@style/MD_ActionButton.Text" />
-
-        </FrameLayout>
-
-    </RelativeLayout>
-
-    <LinearLayout
-        android:id="@+id/buttonStackedFrame"
-        android:orientation="vertical"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/md_button_frame_vertical_padding"
-        android:layout_marginBottom="@dimen/md_button_frame_vertical_padding">
-
-        <FrameLayout
-            android:id="@+id/buttonStackedPositive"
-            style="@style/MD_ActionButtonStacked">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                tools:text="Positive"
-                style="@style/MD_ActionButton.Text" />
-
-        </FrameLayout>
-
-        <FrameLayout
-            android:id="@+id/buttonStackedNegative"
-            style="@style/MD_ActionButtonStacked">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                tools:text="Negative"
-                style="@style/MD_ActionButton.Text" />
-
-        </FrameLayout>
-
-        <FrameLayout
-            android:id="@+id/buttonStackedNeutral"
-            style="@style/MD_ActionButtonStacked">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                tools:text="Neutral"
-                style="@style/MD_ActionButton.Text" />
-
-        </FrameLayout>
-
-    </LinearLayout>
+    <com.afollestad.materialdialogs.internal.MDButton
+        android:id="@+id/buttonDefaultPositive"
+        style="@style/MD_ActionButton.Text"
+        tools:layout_alignParentLeft="true"
+        tools:layout_alignParentStart="true"
+        tools:text="Positive"
+        />
 
 </merge>

--- a/library/src/main/res/layout/md_stub_progress_indeterminate.xml
+++ b/library/src/main/res/layout/md_stub_progress_indeterminate.xml
@@ -4,14 +4,16 @@
     android:orientation="horizontal"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:paddingLeft="@dimen/md_dialog_frame_margin"
+    android:paddingRight="@dimen/md_dialog_frame_margin"
+    android:paddingTop="@dimen/md_content_padding_top"
+    android:paddingBottom="@dimen/md_content_padding_top"
     android:gravity="end|center_vertical">
 
     <ProgressBar
         android:id="@android:id/progress"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginLeft="@dimen/md_dialog_frame_margin"
-        android:layout_marginStart="@dimen/md_dialog_frame_margin" />
+        android:layout_height="wrap_content" />
 
     <TextView
         android:id="@+id/content"
@@ -21,6 +23,8 @@
         android:textSize="16sp"
         tools:text="Message"
         tools:ignore="UnusedAttribute"
+        android:paddingLeft="16dp"
+        android:paddingStart="16dp"
         android:gravity="start"
         android:textAlignment="viewStart" />
 

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -1,29 +1,58 @@
 <resources>
     <!-- See http://www.google.com/design/spec/components/dialogs.html#dialogs-specs -->
+
+    <!-- Notes:
+
+        The specs specify 16dp between the content and the buttons and imply 16dp between
+        the title and the content. Also 24dp above the title and 8dp below the buttons.
+
+        Additionally, we interpret:
+         16dp between title and content
+         24dp above content if there is no title
+         24dp below content if there is no button bar
+
+        When dialog is large enough to scroll, some padding is removed to make space and
+        keep things symmetrical.
+        Reduced paddings are:
+         8dp above content if there is no title (0dp when scrolled)
+         8dp below content if there is no button bar (0dp when scrolled)
+         8dp between content and button bar
+         0dp below button bar
+
+        For implementation:
+         Content view gets 8dp vertical padding
+         Title bar gets 24dp top, 8dp bottom
+         Buttons get 8dp bottom
+         Stacked buttons get 24dp end padding, the spec's 16 plus the spec's 8dp button padding
+
+         MDRootLayout takes care of margins when no title or not button bar,
+         and the margin between buttons and content when not scrolling.
+    -->
+
     <!-- Margin around the dialog, excluding the button bar -->
     <dimen name="md_dialog_frame_margin">24dp</dimen>
-    <dimen name="md_title_frame_margin_bottom">16dp</dimen>
-    <dimen name="md_title_frame_margin_bottom_list">4dp</dimen>
+    <!-- Total title margin bottom is 16, but we split this between content and title -->
+    <dimen name="md_title_frame_margin_bottom">8dp</dimen>
+    <!-- The desired padding when no title is visible,
+         This plus md_content_padding_top should equals md_dialog_frame_margin -->
+    <dimen name="md_notitle_vertical_padding">16dp</dimen>
+
+    <dimen name="md_content_padding_top">8dp</dimen>
+
     <dimen name="md_button_min_width">42dp</dimen>
-    <!-- Above and below buttons, 36+12=48 for the height of the button frame -->
+    <!-- Above and below buttons, 36+6+6=48 for the height of the button frame -->
     <dimen name="md_button_inset_vertical">6dp</dimen>
     <dimen name="md_button_inset_horizontal">4dp</dimen>
     <dimen name="md_button_textpadding_horizontal">1dp</dimen>
     <dimen name="md_button_padding_horizontal">8dp</dimen>
     <dimen name="md_button_padding_vertical">4dp</dimen>
     <dimen name="md_button_padding_horizontal_internalexternal">32dp</dimen>
-    <!-- 16dp - 4dp (inset) -->
+    <!-- 16dp - 4dp (inset from background drawable) -->
     <dimen name="md_button_padding_frame_side">12dp</dimen>
     <dimen name="md_neutral_button_margin">12dp</dimen>
-    <!--
-            Applied to content scrollview/listview and customview, the spec calls for 16dp between the
-             bottom of the content and the top of the button bar, we split this between the two for
-             ease of layouts and adjustments. Likewise the spec implies 16dp between the title and
-             content and we split that as well.
 
-             Splitting makes it easier to have consistent padding against the dividers.
-    -->
-    <dimen name="md_content_vertical_padding">8dp</dimen>
+    <!-- actual content padding bottom is 16dp, but we split between button bar and content -->
+    <dimen name="md_content_padding_bottom">8dp</dimen>
     <dimen name="md_button_frame_vertical_padding">8dp</dimen>
     <dimen name="md_button_height">48dp</dimen>
     <dimen name="md_title_textsize">18sp</dimen>
@@ -36,5 +65,6 @@
     <dimen name="md_icon_max_size">48dp</dimen>
     <dimen name="md_listitem_margin_left">24dp</dimen>
     <dimen name="md_action_corner_radius">2dp</dimen>
+    <dimen name="md_divider_height">1dp</dimen>
 
 </resources>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -49,7 +49,6 @@
         <item name="android:minWidth">@dimen/md_button_min_width</item>
         <item name="android:paddingLeft">@dimen/md_button_textpadding_horizontal</item>
         <item name="android:paddingRight">@dimen/md_button_textpadding_horizontal</item>
-        <item name="android:duplicateParentState">true</item>
     </style>
 
     <!-- Light dialog theme for devices prior Honeycomb -->


### PR DESCRIPTION
The previous setup was causing lag when showing or updating the dialog,
because it needed to wait until everything was laid out before adjusting
the padding, which would trigger a second layout.

This method uses a custom ViewGroup (MDRootLayout) which determines
padding and button stacking onMeasure.

Changes were also made with how the padding was split up, to avoid having to
move padding between views.