### PR TITLE
adds support for optionally specifying an InputType for the .input() edi...

### DIFF
--- a/library/src/main/java/com/afollestad/materialdialogs/DialogInit.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/DialogInit.java
@@ -382,6 +382,8 @@ class DialogInit {
                 }
             });
         }
+        if (builder.inputType != -1)
+            dialog.input.setInputType(builder.inputType);
         dialog.input.setHint(builder.inputHint);
         dialog.input.setSingleLine();
         dialog.input.setTextColor(builder.contentColor);

--- a/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -379,6 +379,7 @@ public class MaterialDialog extends DialogBase implements
         protected CharSequence inputPrefill;
         protected CharSequence inputHint;
         protected InputCallback inputCallback;
+        protected int inputType = -1;
         protected boolean alwaysCallInputCallback;
 
         protected boolean titleColorSet = false;
@@ -981,6 +982,15 @@ public class MaterialDialog extends DialogBase implements
 
         public Builder input(@StringRes int hint, @StringRes int prefill, @NonNull InputCallback callback) {
             return input(hint == 0 ? null : context.getString(hint), prefill == 0 ? null : context.getString(prefill), callback);
+        }
+
+        public Builder input(CharSequence hint, CharSequence prefill, @NonNull InputCallback callback, int inputType) {
+            this.inputType = inputType;
+            return input(hint, prefill, callback);
+        }
+
+        public Builder input(@StringRes int hint, @StringRes int prefill, @NonNull InputCallback callback, int inputType) {
+            return input(hint == 0 ? null : context.getString(hint), prefill == 0 ? null : context.getString(prefill), callback, inputType);
         }
 
         public Builder alwaysCallInputCallback() {


### PR DESCRIPTION
Basically, I wanted an EditText for an email address inside a Material Dialog. This saves some time compared to creating a custom view. Hopefully others could benefit from this change too.

Backwards compatibility is also kept with the pull request, as the new methods overload the existing two for `.input()`