### PR TITLE
Added JitPack dependency information

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ repositories {
 This will reference Bintray's Maven repository that contains material-dialogs directly, rather
 than going through jCenter first.
 
+### Install
+
+[![JitPack](https://img.shields.io/github/release/afollestad/material-dialogs.svg?label=JitPack) ](https://jitpack.io/#afollestad/material-dialogs)
+
+You can also install using [JitPack](https://jitpack.io/#afollestad/material-dialogs):
+
+```Gradle
+repositories {
+    maven { url "https://jitpack.io" }
+}
+dependencies {
+    compile 'com.github.afollestad:material-dialogs:v0.7.3.1'
+}
+```
+
 ---
 
 # What's New


### PR DESCRIPTION
Hi!

Added JitPack dependency information to the readme so that its easy to copy-paste. Some of our users are installing material-dialogs from JitPack.io and hopefully this will help them.

