### PR TITLE
Set positive button enable status on every invalidation.

### DIFF
--- a/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -1447,7 +1447,7 @@ public class MaterialDialog extends DialogBase implements
             inputMinMax.setTextColor(colorText);
             MDTintHelper.setTint(input, colorWidget);
             final View positiveAb = getActionButton(DialogAction.POSITIVE);
-            if (positiveAb.isEnabled()) positiveAb.setEnabled(!overMax);
+            positiveAb.setEnabled(!overMax);
         }
     }
 


### PR DESCRIPTION
If the max length is reached, the positive button is disabled.  The button is not re-enabled even if text is deleted to be less than the max length.  The button is not enabled after the max length is passed, so it cannot be re-enabled because of the isEnabled() check before setting the status.