### PR TITLE
Add orientation change support to preferences

### DIFF
--- a/library/src/main/java/com/afollestad/materialdialogs/prefs/MaterialEditTextPreference.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/prefs/MaterialEditTextPreference.java
@@ -2,7 +2,6 @@ package com.afollestad.materialdialogs.prefs;
 
 import android.app.Dialog;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcel;
@@ -49,6 +48,8 @@ public class MaterialEditTextPreference extends EditTextPreference {
         mColor = DialogUtils.resolveColor(context, R.attr.colorAccent, fallback);
 
         mEditText = new AppCompatEditText(context, attrs);
+        // Give it an ID so it can be saved/restored
+        mEditText.setId(android.R.id.edit);
         mEditText.setEnabled(true);
     }
 
@@ -58,22 +59,26 @@ public class MaterialEditTextPreference extends EditTextPreference {
 
     @Override
     protected void onAddEditTextToDialogView(@NonNull View dialogView, @NonNull EditText editText) {
-        if (editText.getParent() != null)
-            ((ViewGroup) mEditText.getParent()).removeView(editText);
         ((ViewGroup) dialogView).addView(editText, new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
     }
 
     @Override
     protected void onBindDialogView(@NonNull View view) {
-        mEditText.setText("");
-        if (getText() != null)
-            mEditText.setText(getText());
-        ViewParent oldParent = mEditText.getParent();
+        EditText editText = mEditText;
+        editText.setText(getText());
+
+        // Initialize cursor to end of text
+        if (editText.getText().length() > 0) {
+            editText.setSelection(editText.length());
+        }
+
+        ViewParent oldParent = editText.getParent();
         if (oldParent != view) {
-            if (oldParent != null)
-                ((ViewGroup) oldParent).removeView(mEditText);
-            onAddEditTextToDialogView(view, mEditText);
+            if (oldParent != null) {
+                ((ViewGroup) oldParent).removeView(editText);
+            }
+            onAddEditTextToDialogView(view, editText);
         }
     }
 
@@ -105,14 +110,7 @@ public class MaterialEditTextPreference extends EditTextPreference {
                 .positiveText(getPositiveButtonText())
                 .negativeText(getNegativeButtonText())
                 .callback(callback)
-                .dismissListener(this)
-                .showListener(new DialogInterface.OnShowListener() {
-                    @Override
-                    public void onShow(DialogInterface dialog) {
-                        if (mEditText.getText().length() > 0)
-                            mEditText.setSelection(mEditText.length());
-                    }
-                });
+                .dismissListener(this);
 
         View layout = LayoutInflater.from(getContext()).inflate(R.layout.md_stub_inputpref, null);
         onBindDialogView(layout);

--- a/library/src/main/java/com/afollestad/materialdialogs/prefs/MaterialEditTextPreference.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/prefs/MaterialEditTextPreference.java
@@ -5,6 +5,8 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.preference.EditTextPreference;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
@@ -171,5 +173,68 @@ public class MaterialEditTextPreference extends EditTextPreference {
         super.onActivityDestroy();
         if (mDialog != null && mDialog.isShowing())
             mDialog.dismiss();
+    }
+
+    @Override
+    protected Parcelable onSaveInstanceState() {
+        final Parcelable superState = super.onSaveInstanceState();
+        Dialog dialog = getDialog();
+        if (dialog == null || !dialog.isShowing()) {
+            return superState;
+        }
+
+        final SavedState myState = new SavedState(superState);
+        myState.isDialogShowing = true;
+        myState.dialogBundle = dialog.onSaveInstanceState();
+        return myState;
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Parcelable state) {
+        if (state == null || !state.getClass().equals(SavedState.class)) {
+            // Didn't save state for us in onSaveInstanceState
+            super.onRestoreInstanceState(state);
+            return;
+        }
+
+        SavedState myState = (SavedState) state;
+        super.onRestoreInstanceState(myState.getSuperState());
+        if (myState.isDialogShowing) {
+            showDialog(myState.dialogBundle);
+        }
+    }
+
+    // From DialogPreference
+    private static class SavedState extends BaseSavedState {
+        boolean isDialogShowing;
+        Bundle dialogBundle;
+
+        public SavedState(Parcel source) {
+            super(source);
+            isDialogShowing = source.readInt() == 1;
+            dialogBundle = source.readBundle();
+        }
+
+        @Override
+        public void writeToParcel(Parcel dest, int flags) {
+            super.writeToParcel(dest, flags);
+            dest.writeInt(isDialogShowing ? 1 : 0);
+            dest.writeBundle(dialogBundle);
+        }
+
+        public SavedState(Parcelable superState) {
+            super(superState);
+        }
+
+        public static final Parcelable.Creator<SavedState> CREATOR =
+                new Parcelable.Creator<SavedState>() {
+                    public SavedState createFromParcel(Parcel in) {
+                        return new SavedState(in);
+                    }
+
+                    public SavedState[] newArray(int size) {
+                        return new SavedState[size];
+                    }
+                };
     }
 }

--- a/library/src/main/java/com/afollestad/materialdialogs/prefs/MaterialListPreference.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/prefs/MaterialListPreference.java
@@ -5,6 +5,8 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.preference.ListPreference;
 import android.preference.PreferenceManager;
 import android.text.TextUtils;
@@ -121,5 +123,68 @@ public class MaterialListPreference extends ListPreference {
             if (!TextUtils.equals(value, oldValue))
                 notifyChanged();
         }
+    }
+
+    @Override
+    protected Parcelable onSaveInstanceState() {
+        final Parcelable superState = super.onSaveInstanceState();
+        Dialog dialog = getDialog();
+        if (dialog == null || !dialog.isShowing()) {
+            return superState;
+        }
+
+        final SavedState myState = new SavedState(superState);
+        myState.isDialogShowing = true;
+        myState.dialogBundle = dialog.onSaveInstanceState();
+        return myState;
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Parcelable state) {
+        if (state == null || !state.getClass().equals(SavedState.class)) {
+            // Didn't save state for us in onSaveInstanceState
+            super.onRestoreInstanceState(state);
+            return;
+        }
+
+        SavedState myState = (SavedState) state;
+        super.onRestoreInstanceState(myState.getSuperState());
+        if (myState.isDialogShowing) {
+            showDialog(myState.dialogBundle);
+        }
+    }
+
+    // From DialogPreference
+    private static class SavedState extends BaseSavedState {
+        boolean isDialogShowing;
+        Bundle dialogBundle;
+
+        public SavedState(Parcel source) {
+            super(source);
+            isDialogShowing = source.readInt() == 1;
+            dialogBundle = source.readBundle();
+        }
+
+        @Override
+        public void writeToParcel(Parcel dest, int flags) {
+            super.writeToParcel(dest, flags);
+            dest.writeInt(isDialogShowing ? 1 : 0);
+            dest.writeBundle(dialogBundle);
+        }
+
+        public SavedState(Parcelable superState) {
+            super(superState);
+        }
+
+        public static final Parcelable.Creator<SavedState> CREATOR =
+                new Parcelable.Creator<SavedState>() {
+                    public SavedState createFromParcel(Parcel in) {
+                        return new SavedState(in);
+                    }
+
+                    public SavedState[] newArray(int size) {
+                        return new SavedState[size];
+                    }
+                };
     }
 }

--- a/sample/src/main/java/com/afollestad/materialdialogssample/PreferenceActivity.java
+++ b/sample/src/main/java/com/afollestad/materialdialogssample/PreferenceActivity.java
@@ -22,7 +22,10 @@ public class PreferenceActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.preference_activity_custom);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-        getFragmentManager().beginTransaction().replace(R.id.content_frame, new SettingsFragment()).commit();
+
+        if (getFragmentManager().findFragmentById(R.id.content_frame) == null) {
+            getFragmentManager().beginTransaction().replace(R.id.content_frame, new SettingsFragment()).commit();
+        }
     }
 
     @Override


### PR DESCRIPTION
Updated `MaterialListPreference`, `MaterialEditTextPreference`, and `MaterialMultiSelectListPreference` to support orientation changes. All three now continue to show their dialog on orientation change. In addition, `MaterialEditTextPreference` correctly maintains the text and cursor position on orientation change.

Also fixed the sample app to not create a new `SettingsFragment` every time on orientation change (which prevented the preferences from being saved/restored).
