### PR TITLE
Add support for using ColorStateLists to specify button text colors

### DIFF
--- a/library/src/main/java/com/afollestad/materialdialogs/DialogInit.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/DialogInit.java
@@ -84,11 +84,11 @@ class DialogInit {
 
         // Retrieve action button colors from theme attributes or the Builder
         if (!builder.positiveColorSet)
-            builder.positiveColor = DialogUtils.resolveColor(builder.context, R.attr.md_positive_color, builder.positiveColor);
+            builder.positiveColor = DialogUtils.resolveActionTextColorStateList(builder.context, R.attr.md_positive_color, builder.positiveColor);
         if (!builder.neutralColorSet)
-            builder.neutralColor = DialogUtils.resolveColor(builder.context, R.attr.md_neutral_color, builder.neutralColor);
+            builder.neutralColor = DialogUtils.resolveActionTextColorStateList(builder.context, R.attr.md_neutral_color, builder.neutralColor);
         if (!builder.negativeColorSet)
-            builder.negativeColor = DialogUtils.resolveColor(builder.context, R.attr.md_negative_color, builder.negativeColor);
+            builder.negativeColor = DialogUtils.resolveActionTextColorStateList(builder.context, R.attr.md_negative_color, builder.negativeColor);
         if (!builder.widgetColorSet)
             builder.widgetColor = DialogUtils.resolveColor(builder.context, R.attr.md_widget_color, builder.widgetColor);
 
@@ -198,7 +198,7 @@ class DialogInit {
             dialog.content.setMovementMethod(new LinkMovementMethod());
             dialog.setTypeface(dialog.content, builder.regularFont);
             dialog.content.setLineSpacing(0f, builder.contentLineSpacingMultiplier);
-            if (builder.positiveColor == 0)
+            if (builder.positiveColor == null)
                 dialog.content.setLinkTextColor(DialogUtils.resolveColor(dialog.getContext(), android.R.attr.textColorPrimary));
             else
                 dialog.content.setLinkTextColor(builder.positiveColor);
@@ -234,7 +234,7 @@ class DialogInit {
         dialog.setTypeface(positiveTextView, builder.mediumFont);
         positiveTextView.setAllCapsCompat(textAllCaps);
         positiveTextView.setText(builder.positiveText);
-        positiveTextView.setTextColor(getActionTextStateList(builder.context, builder.positiveColor));
+        positiveTextView.setTextColor(builder.positiveColor);
         dialog.positiveButton.setStackedSelector(dialog.getButtonSelector(DialogAction.POSITIVE, true));
         dialog.positiveButton.setDefaultSelector(dialog.getButtonSelector(DialogAction.POSITIVE, false));
         dialog.positiveButton.setTag(DialogAction.POSITIVE);
@@ -245,7 +245,7 @@ class DialogInit {
         dialog.setTypeface(negativeTextView, builder.mediumFont);
         negativeTextView.setAllCapsCompat(textAllCaps);
         negativeTextView.setText(builder.negativeText);
-        negativeTextView.setTextColor(getActionTextStateList(builder.context, builder.negativeColor));
+        negativeTextView.setTextColor(builder.negativeColor);
         dialog.negativeButton.setStackedSelector(dialog.getButtonSelector(DialogAction.NEGATIVE, true));
         dialog.negativeButton.setDefaultSelector(dialog.getButtonSelector(DialogAction.NEGATIVE, false));
         dialog.negativeButton.setTag(DialogAction.NEGATIVE);
@@ -256,7 +256,7 @@ class DialogInit {
         dialog.setTypeface(neutralTextView, builder.mediumFont);
         neutralTextView.setAllCapsCompat(textAllCaps);
         neutralTextView.setText(builder.neutralText);
-        neutralTextView.setTextColor(getActionTextStateList(builder.context, builder.neutralColor));
+        neutralTextView.setTextColor(builder.neutralColor);
         dialog.neutralButton.setStackedSelector(dialog.getButtonSelector(DialogAction.NEUTRAL, true));
         dialog.neutralButton.setDefaultSelector(dialog.getButtonSelector(DialogAction.NEUTRAL, false));
         dialog.neutralButton.setTag(DialogAction.NEUTRAL);
@@ -426,19 +426,4 @@ class DialogInit {
             dialog.inputMinMax = null;
         }
     }
-
-    private static ColorStateList getActionTextStateList(Context context, int newPrimaryColor) {
-        final int fallBackButtonColor = DialogUtils.resolveColor(context, android.R.attr.textColorPrimary);
-        if (newPrimaryColor == 0) newPrimaryColor = fallBackButtonColor;
-        int[][] states = new int[][]{
-                new int[]{-android.R.attr.state_enabled}, // disabled
-                new int[]{} // enabled
-        };
-        int[] colors = new int[]{
-                DialogUtils.adjustAlpha(newPrimaryColor, 0.4f),
-                newPrimaryColor
-        };
-        return new ColorStateList(states, colors);
-    }
-
 }

--- a/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -3,6 +3,7 @@ package com.afollestad.materialdialogs;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.res.ColorStateList;
 import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
@@ -369,9 +370,9 @@ public class MaterialDialog extends DialogBase implements
         protected CharSequence negativeText;
         protected View customView;
         protected int widgetColor;
-        protected int positiveColor;
-        protected int negativeColor;
-        protected int neutralColor;
+        protected ColorStateList positiveColor;
+        protected ColorStateList negativeColor;
+        protected ColorStateList neutralColor;
         protected ButtonCallback callback;
         protected ListCallback listCallback;
         protected ListCallbackSingleChoice listCallbackSingleChoice;
@@ -463,9 +464,9 @@ public class MaterialDialog extends DialogBase implements
                 this.widgetColor = DialogUtils.resolveColor(context, android.R.attr.colorAccent, this.widgetColor);
             }
 
-            this.positiveColor = this.widgetColor;
-            this.negativeColor = this.widgetColor;
-            this.neutralColor = this.widgetColor;
+            this.positiveColor = DialogUtils.getActionTextStateList(context, this.widgetColor);
+            this.negativeColor = DialogUtils.getActionTextStateList(context, this.widgetColor);
+            this.neutralColor = DialogUtils.getActionTextStateList(context, this.widgetColor);
 
             this.progressPercentFormat = NumberFormat.getPercentInstance();
             this.progressNumberFormat = "%1d/%2d";
@@ -514,11 +515,11 @@ public class MaterialDialog extends DialogBase implements
                 this.titleColor = s.titleColor;
             if (s.contentColor != 0)
                 this.contentColor = s.contentColor;
-            if (s.positiveColor != 0)
+            if (s.positiveColor != null)
                 this.positiveColor = s.positiveColor;
-            if (s.neutralColor != 0)
+            if (s.neutralColor != null)
                 this.neutralColor = s.neutralColor;
-            if (s.negativeColor != 0)
+            if (s.negativeColor != null)
                 this.negativeColor = s.negativeColor;
             if (s.itemColor != 0)
                 this.itemColor = s.itemColor;
@@ -782,17 +783,21 @@ public class MaterialDialog extends DialogBase implements
         }
 
         public Builder positiveColor(@ColorInt int color) {
-            this.positiveColor = color;
-            this.positiveColorSet = true;
-            return this;
+            return positiveColor(DialogUtils.getActionTextStateList(context, color));
         }
 
         public Builder positiveColorRes(@ColorRes int colorRes) {
-            return positiveColor(this.context.getResources().getColor(colorRes));
+            return positiveColor(DialogUtils.getActionTextColorStateList(this.context, colorRes));
         }
 
         public Builder positiveColorAttr(@AttrRes int colorAttr) {
-            return positiveColor(DialogUtils.resolveColor(this.context, colorAttr));
+            return positiveColor(DialogUtils.resolveActionTextColorStateList(this.context, colorAttr, null));
+        }
+
+        public Builder positiveColor(ColorStateList colorStateList) {
+            this.positiveColor = colorStateList;
+            this.positiveColorSet = true;
+            return this;
         }
 
         public Builder neutralText(@StringRes int neutralRes) {
@@ -805,17 +810,21 @@ public class MaterialDialog extends DialogBase implements
         }
 
         public Builder negativeColor(@ColorInt int color) {
-            this.negativeColor = color;
-            this.negativeColorSet = true;
-            return this;
+            return negativeColor(DialogUtils.getActionTextStateList(context, color));
         }
 
         public Builder negativeColorRes(@ColorRes int colorRes) {
-            return negativeColor(this.context.getResources().getColor(colorRes));
+            return negativeColor(DialogUtils.getActionTextColorStateList(this.context, colorRes));
         }
 
         public Builder negativeColorAttr(@AttrRes int colorAttr) {
-            return negativeColor(DialogUtils.resolveColor(this.context, colorAttr));
+            return negativeColor(DialogUtils.resolveActionTextColorStateList(this.context, colorAttr, null));
+        }
+
+        public Builder negativeColor(ColorStateList colorStateList) {
+            this.negativeColor = colorStateList;
+            this.negativeColorSet = true;
+            return this;
         }
 
         public Builder negativeText(@StringRes int negativeRes) {
@@ -828,17 +837,21 @@ public class MaterialDialog extends DialogBase implements
         }
 
         public Builder neutralColor(@ColorInt int color) {
-            this.neutralColor = color;
-            this.neutralColorSet = true;
-            return this;
+            return neutralColor(DialogUtils.getActionTextStateList(context, color));
         }
 
         public Builder neutralColorRes(@ColorRes int colorRes) {
-            return neutralColor(this.context.getResources().getColor(colorRes));
+            return neutralColor(DialogUtils.getActionTextColorStateList(this.context, colorRes));
         }
 
         public Builder neutralColorAttr(@AttrRes int colorAttr) {
-            return neutralColor(DialogUtils.resolveColor(this.context, colorAttr));
+            return neutralColor(DialogUtils.resolveActionTextColorStateList(this.context, colorAttr, null));
+        }
+
+        public Builder neutralColor(ColorStateList colorStateList) {
+            this.neutralColor = colorStateList;
+            this.neutralColorSet = true;
+            return this;
         }
 
         public Builder listSelector(@DrawableRes int selectorRes) {

--- a/library/src/main/java/com/afollestad/materialdialogs/ThemeSingleton.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/ThemeSingleton.java
@@ -1,5 +1,6 @@
 package com.afollestad.materialdialogs;
 
+import android.content.res.ColorStateList;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.ColorInt;
 import android.support.annotation.DrawableRes;
@@ -27,11 +28,11 @@ public class ThemeSingleton {
     @ColorInt
     public int contentColor = 0;
     @ColorInt
-    public int positiveColor = 0;
+    public ColorStateList positiveColor = null;
     @ColorInt
-    public int neutralColor = 0;
+    public ColorStateList neutralColor = null;
     @ColorInt
-    public int negativeColor = 0;
+    public ColorStateList negativeColor = null;
     @ColorInt
     public int widgetColor = 0;
     @ColorInt

--- a/library/src/main/java/com/afollestad/materialdialogs/util/DialogUtils.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/util/DialogUtils.java
@@ -2,11 +2,13 @@ package com.afollestad.materialdialogs.util;
 
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.support.annotation.AttrRes;
+import android.support.annotation.ColorRes;
 import android.util.TypedValue;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
@@ -37,6 +39,41 @@ public class DialogUtils {
             return a.getColor(0, fallback);
         } finally {
             a.recycle();
+        }
+    }
+
+    // Try to resolve the colorAttr attribute.
+    public static ColorStateList resolveActionTextColorStateList(Context context, @AttrRes int colorAttr, ColorStateList fallback) {
+        TypedArray a = context.getTheme().obtainStyledAttributes(new int[]{colorAttr});
+        try {
+            final TypedValue value = a.peekValue(0);
+            if (value == null) {
+                return fallback;
+            }
+            if (value.type >= TypedValue.TYPE_FIRST_COLOR_INT && value.type <= TypedValue.TYPE_LAST_COLOR_INT) {
+                return getActionTextStateList(context, value.data);
+            } else {
+                final ColorStateList stateList = a.getColorStateList(0);
+                if (stateList != null) {
+                    return stateList;
+                } else {
+                    return fallback;
+                }
+            }
+        } finally {
+            a.recycle();
+        }
+    }
+
+    // Get the specified color resource, creating a ColorStateList if the resource
+    // points to a color value.
+    public static ColorStateList getActionTextColorStateList(Context context, @ColorRes int colorId) {
+        final TypedValue value = new TypedValue();
+        context.getResources().getValue(colorId, value, true);
+        if (value.type >= TypedValue.TYPE_FIRST_COLOR_INT && value.type <= TypedValue.TYPE_LAST_COLOR_INT) {
+            return getActionTextStateList(context, value.data);
+        } else {
+            return context.getResources().getColorStateList(colorId);
         }
     }
 
@@ -155,5 +192,20 @@ public class DialogUtils {
                     imm.hideSoftInputFromWindow(dialog.getInputEditText().getWindowToken(), 0);
             }
         });
+    }
+
+
+    public static ColorStateList getActionTextStateList(Context context, int newPrimaryColor) {
+        final int fallBackButtonColor = DialogUtils.resolveColor(context, android.R.attr.textColorPrimary);
+        if (newPrimaryColor == 0) newPrimaryColor = fallBackButtonColor;
+        int[][] states = new int[][]{
+                new int[]{-android.R.attr.state_enabled}, // disabled
+                new int[]{} // enabled
+        };
+        int[] colors = new int[]{
+                DialogUtils.adjustAlpha(newPrimaryColor, 0.4f),
+                newPrimaryColor
+        };
+        return new ColorStateList(states, colors);
     }
 }

--- a/sample/src/main/java/com/afollestad/materialdialogssample/MainActivity.java
+++ b/sample/src/main/java/com/afollestad/materialdialogssample/MainActivity.java
@@ -29,6 +29,7 @@ import com.afollestad.materialdialogs.ThemeSingleton;
 import com.afollestad.materialdialogs.internal.MDTintHelper;
 import com.afollestad.materialdialogs.simplelist.MaterialSimpleListAdapter;
 import com.afollestad.materialdialogs.simplelist.MaterialSimpleListItem;
+import com.afollestad.materialdialogs.util.DialogUtils;
 
 import java.io.File;
 
@@ -567,9 +568,9 @@ public class MainActivity extends AppCompatActivity implements
         selectedColorIndex = index;
         //noinspection ConstantConditions
         getSupportActionBar().setBackgroundDrawable(new ColorDrawable(color));
-        ThemeSingleton.get().positiveColor = color;
-        ThemeSingleton.get().neutralColor = color;
-        ThemeSingleton.get().negativeColor = color;
+        ThemeSingleton.get().positiveColor = DialogUtils.getActionTextStateList(this, color);
+        ThemeSingleton.get().neutralColor = DialogUtils.getActionTextStateList(this, color);
+        ThemeSingleton.get().negativeColor = DialogUtils.getActionTextStateList(this, color);
         ThemeSingleton.get().widgetColor = color;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             getWindow().setStatusBarColor(darker);


### PR DESCRIPTION
Add support for using ColorStateLists to specify button text colors. This allows for the user to customize not just the active color of button text, but also the color disabled button text.

This PR modifies all of the color handling methods - `positiveColor(`), `positiveColorRes()`, `positiveColorAttr()`, `negativeColor()`, `negativeColorRes()`, `negativeColorAttr()`, `neutralColor()`, `neutralColorRes()`, and `neutralColorAttr()` - to be able use either a simple color value, or a ColorStateList. This is accomplished with new helper methods in `DialogInit` that will first check to see if a resource points to a color - if it does, it uses the existing method `getActionTextStateList()` to convert it to a ColorState list. However, it it points to a ColorStateList, it just loads the ColorStateList directly.

The style attributes, `md_positive_color`, `md_negative_color`, and `md_neutral_color` also can now work with either a simple color or a reference to a color state list.