### PR TITLE
Use sensible defaults for widths on tablets.

### DIFF
--- a/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -1166,7 +1166,16 @@ public class MaterialDialog extends DialogBase implements
 
         @UiThread
         public MaterialDialog build() {
-            return new MaterialDialog(this);
+            MaterialDialog d = new MaterialDialog(this);
+
+            if (context.getResources().getBoolean(R.bool.md_is_tablet)) {
+                WindowManager.LayoutParams lp = new WindowManager.LayoutParams();
+                lp.copyFrom(d.getWindow().getAttributes());
+                lp.width = context.getResources().getDimensionPixelSize(R.dimen.md_default_dialog_width);
+                d.getWindow().setAttributes(lp);
+            }
+
+            return d;
         }
 
         @UiThread

--- a/library/src/main/res/values-sw600dp/bool.xml
+++ b/library/src/main/res/values-sw600dp/bool.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="md_is_tablet">true</bool>
+</resources>

--- a/library/src/main/res/values-sw600dp/dimens.xml
+++ b/library/src/main/res/values-sw600dp/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="md_default_dialog_width">446dp</dimen>
+</resources>

--- a/library/src/main/res/values-sw720dp/bool.xml
+++ b/library/src/main/res/values-sw720dp/bool.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="md_is_tablet">true</bool>
+</resources>

--- a/library/src/main/res/values-sw720dp/dimens.xml
+++ b/library/src/main/res/values-sw720dp/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="md_default_dialog_width">480dp</dimen>
+</resources>

--- a/library/src/main/res/values/bool.xml
+++ b/library/src/main/res/values/bool.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="md_is_tablet">false</bool>
+</resources>

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -73,5 +73,6 @@
 
     <dimen name="md_bg_corner_radius">2dp</dimen>
     <dimen name="circular_progress_border">4dp</dimen>
+    <dimen name="md_default_dialog_width">0dp</dimen>
 
 </resources>


### PR DESCRIPTION
This implements some sensible widths for dialogs on tablets. Before, they often went nearly edge-to-edge with some minor padding on the sides, and the material design spec doesn't provide much help here. We had a long discussion about how best to go about this, with the ideal solution being to automagically create the best experience based on preferred line length. Handling every possible case of that is going to be a lot of tedious work though.

This is a simpler approach, where we basically say up front what we believe a good width is. More specifically, I stole these widths from AOSP's spec for what the notification panel width should be. Toyed with them in our [BottomSheet library](https://github.com/Flipboard/bottomsheet/pull/38), and it turns out they look pretty good here. This is by far the simplest approach, and covers probably 98% of all the use cases.

Resolves #552

Screens:

Landscape

Before | After
---|---
![volantismpz79mhsweers08022015233012](https://cloud.githubusercontent.com/assets/1361086/9031951/89905d40-396e-11e5-8583-89b997f666b7.png) | ![volantismpz79mhsweers08022015232712](https://cloud.githubusercontent.com/assets/1361086/9031954/8f1fcb6a-396e-11e5-842f-bfbd9f1a8b7c.png)

Portrait

Before | After
---|---
![volantismpz79mhsweers08022015233155](https://cloud.githubusercontent.com/assets/1361086/9031969/af291c40-396e-11e5-959d-88e33e99cc7a.png) | ![volantismpz79mhsweers08022015232653](https://cloud.githubusercontent.com/assets/1361086/9031959/a15bf538-396e-11e5-9869-28efa9442a6d.png)

Before | After
---|---
![volantismpz79mhsweers08022015233325](https://cloud.githubusercontent.com/assets/1361086/9031990/e8c524da-396e-11e5-955d-831ebb3c41a2.png) | ![volantismpz79mhsweers08022015232645](https://cloud.githubusercontent.com/assets/1361086/9031995/f51593fa-396e-11e5-8c2a-6d791a047ab6.png)

Before | After
---|---
![volantismpz79mhsweers08022015233502](https://cloud.githubusercontent.com/assets/1361086/9032019/29f799ec-396f-11e5-8bf6-798b6aff45e5.png) | ![volantismpz79mhsweers08022015232621](https://cloud.githubusercontent.com/assets/1361086/9032034/420427bc-396f-11e5-9bf2-608947e56135.png)

Before | After
---|---
![volantismpz79mhsweers08022015233704](https://cloud.githubusercontent.com/assets/1361086/9032052/647a35fc-396f-11e5-96c4-689501ef0f97.png) | ![volantismpz79mhsweers08022015232609](https://cloud.githubusercontent.com/assets/1361086/9032067/92fd8ece-396f-11e5-9b10-12cbaa9954e9.png)

Before | After
---|---
![volantismpz79mhsweers08022015233840](https://cloud.githubusercontent.com/assets/1361086/9032072/9dc8f514-396f-11e5-8566-46287401f6b4.png) | ![volantismpz79mhsweers08022015232548](https://cloud.githubusercontent.com/assets/1361086/9032074/a3bafb70-396f-11e5-8d51-3d6b98439a17.png)
