### PR TITLE
Move tablet width logic to constructor

### DIFF
--- a/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/library/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -89,6 +89,14 @@ public class MaterialDialog extends DialogBase implements
         final LayoutInflater inflater = LayoutInflater.from(builder.context);
         view = (MDRootLayout) inflater.inflate(DialogInit.getInflateLayout(builder), null);
         DialogInit.init(this);
+
+        // Set up width if on tablet
+        if (builder.context.getResources().getBoolean(R.bool.md_is_tablet)) {
+            WindowManager.LayoutParams lp = new WindowManager.LayoutParams();
+            lp.copyFrom(getWindow().getAttributes());
+            lp.width = builder.context.getResources().getDimensionPixelSize(R.dimen.md_default_dialog_width);
+            getWindow().setAttributes(lp);
+        }
     }
 
     public final void setTypeface(TextView target, Typeface t) {
@@ -1166,16 +1174,7 @@ public class MaterialDialog extends DialogBase implements
 
         @UiThread
         public MaterialDialog build() {
-            MaterialDialog d = new MaterialDialog(this);
-
-            if (context.getResources().getBoolean(R.bool.md_is_tablet)) {
-                WindowManager.LayoutParams lp = new WindowManager.LayoutParams();
-                lp.copyFrom(d.getWindow().getAttributes());
-                lp.width = context.getResources().getDimensionPixelSize(R.dimen.md_default_dialog_width);
-                d.getWindow().setAttributes(lp);
-            }
-
-            return d;
+            return new MaterialDialog(this);
         }
 
         @UiThread


### PR DESCRIPTION
Belongs here anyway, and ensures that extended classes with custom builders will work too