### PR TITLE
Add null check before calling list callback

### DIFF
--- a/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -182,7 +182,9 @@ public class MaterialDialog extends DialogBase implements
                 // If auto dismiss is enabled, dismiss the dialog when a list item is selected
                 dismiss();
             }
-            mBuilder.listCallback.onSelection(this, view, position, mBuilder.items[position]);
+            if (mBuilder.listCallback != null) {
+                mBuilder.listCallback.onSelection(this, view, position, mBuilder.items[position]);
+            }
         } else {
             // Default adapter, choice mode
             if (listType == ListType.MULTI) {


### PR DESCRIPTION
Library throws NullPointerException on list item click if I don't provide ListCallback which is unexpected behaviour for android developers.