### PR TITLE
Suggestion about core version in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ You can create basic, list, single/multi choice, progress, input, etc. dialogs w
 ```gradle
 dependencies {
 	...
-    compile('com.github.afollestad.material-dialogs:core:0.8.6.0@aar') {
+    compile('com.github.afollestad.material-dialogs:core:0.8.5.2@aar') {
         transitive = true
     }
 }


### PR DESCRIPTION
I updated older Material-Dialogs version to newer one, but I failed to import core:0.8.6.0 version. I can't see the tag/release of 0.8.6.0 version and I assume that that is a reason of this.

So I suggest that core:0.8.5.2 version should be in the README file because I succeeded to import this.