### PR TITLE
Mention initial copyright year

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Aidan Michael Follestad
+Copyright (c) 2014-2016 Aidan Michael Follestad
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I am not a lawyer but according to http://www.copyright.gov/circs/circ01.pdf (See screenshot of relevant section below) , listing the first year of publication in the copyright is a good thing

![selection_008](https://cloud.githubusercontent.com/assets/829526/12409934/7021c3a6-be95-11e5-8d1a-18f6948571e0.png)