### PR TITLE
Adding TextInputLayout

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.android.support:recyclerview-v7:23.1.1'
     compile 'com.android.support:support-annotations:23.1.1'
+    compile 'com.android.support:design:23.1.1'
     compile 'me.zhanghai.android.materialprogressbar:library:1.1.4'
 }
 

--- a/core/src/main/java/com/afollestad/materialdialogs/DialogInit.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/DialogInit.java
@@ -416,7 +416,9 @@ class DialogInit {
     private static void setupInputDialog(final MaterialDialog dialog) {
         final MaterialDialog.Builder builder = dialog.mBuilder;
         dialog.input = (EditText) dialog.view.findViewById(android.R.id.input);
+        dialog.textInputLayout = (TextInputLayout) dialog.view.findViewById(R.id.text_input_layout);
         if (dialog.input == null) return;
+        dialog.textInputLayout.setErrorEnabled(true);
         dialog.setTypeface(dialog.input, builder.regularFont);
         if (builder.inputPrefill != null)
             dialog.input.setText(builder.inputPrefill);

--- a/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -73,6 +73,7 @@ public class MaterialDialog extends DialogBase implements
     protected TextView mProgressMinMax;
     protected TextView content;
     protected EditText input;
+    protected TextInputLayout textInputLayout;
     protected TextView inputMinMax;
 
     protected MDButton positiveButton;
@@ -1386,6 +1387,11 @@ public class MaterialDialog extends DialogBase implements
     @Nullable
     public final EditText getInputEditText() {
         return input;
+    }
+    
+    @Nullable
+    public TextInputLayout getTextInputLayout(){
+        return textInputLayout;
     }
 
     /**

--- a/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -21,6 +21,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.annotation.UiThread;
+import android.support.design.widget.TextInputLayout;
 import android.support.v4.content.res.ResourcesCompat;
 import android.text.Editable;
 import android.text.TextUtils;

--- a/core/src/main/res/layout/md_dialog_input.xml
+++ b/core/src/main/res/layout/md_dialog_input.xml
@@ -34,15 +34,21 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <EditText
-                android:id="@android:id/input"
+            <android.support.design.widget.TextInputLayout
+                android:id="@+id/text_input_layout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textSize="@dimen/md_content_textsize"
-                tools:ignore="TextFields"
                 android:layout_marginLeft="-2dp"
                 android:layout_marginRight="-2dp"
-                android:layout_marginBottom="1dp" />
+                android:layout_marginBottom="1dp">
+
+                <EditText
+                    android:id="@android:id/input"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textSize="@dimen/md_content_textsize"
+                    tools:ignore="TextFields"/>
+            </android.support.design.widget.TextInputLayout>
 
             <TextView
                 android:id="@+id/minMax"
@@ -53,9 +59,9 @@
                 android:textSize="12sp"
                 android:gravity="end"
                 android:textAlignment="viewEnd"
-                android:layout_alignRight="@android:id/input"
-                android:layout_alignEnd="@android:id/input"
-                android:layout_below="@android:id/input"
+                android:layout_alignRight="@id/text_input_layout"
+                android:layout_alignEnd="@id/text_input_layout"
+                android:layout_below="@id/text_input_layout"
                 android:paddingRight="4dp"
                 android:paddingEnd="4dp"
                 android:fontFamily="sans-serif"


### PR DESCRIPTION
`TextInputLayout` makes developers are able to tell user that wrong text is being typed on input dialog, i.e. through `MaterialDialog.getTextInputLayout().setError(CharSequence errorText)` method.

[This is the example](http://3.bp.blogspot.com/-gaXWagee9fE/VYrWbqqB6KI/AAAAAAAAANw/SIwM30KjP-s/s1600/e.jpg).