### PR TITLE
Fix crash when hiding keyboard before focus gain.

### DIFF
--- a/core/src/main/java/com/afollestad/materialdialogs/util/DialogUtils.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/util/DialogUtils.java
@@ -7,6 +7,7 @@ import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.os.IBinder;
 import android.support.annotation.ArrayRes;
 import android.support.annotation.AttrRes;
 import android.support.annotation.ColorRes;
@@ -222,8 +223,14 @@ public class DialogUtils {
         final MaterialDialog dialog = (MaterialDialog) di;
         if (dialog.getInputEditText() == null) return;
         InputMethodManager imm = (InputMethodManager) builder.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
-        if (imm != null)
-            imm.hideSoftInputFromWindow(dialog.getCurrentFocus().getWindowToken(), 0);
+        if (imm != null) {
+            final View currentFocus = dialog.getCurrentFocus();
+            final IBinder windowToken = currentFocus != null ?
+                    currentFocus.getWindowToken() : dialog.getView().getWindowToken();
+            if (windowToken != null) {
+                imm.hideSoftInputFromWindow(windowToken, 0);
+            }
+        }
     }
 
     public static ColorStateList getActionTextStateList(Context context, int newPrimaryColor) {


### PR DESCRIPTION
In some rare cases if the user accidentally dismisses a dialog before an EditText widget gains focus, DialogUtils.hideKeyboard will instruct InputMethodManager to hide the softkeyboard using the currently focussed View, which is not yet available and therefore crashes.  This also happens pretty much all the time during monkeyrunner tests, as the series of events there is so quick and this race condition manifests very easily.

This change attempts to use the dialog's View instance to get a window token if the focus is not yet on any valid element, and if that is not yet available for some reason, will not hide the softkeyboard (which
might be better than crashing in this case).

I'm not entirely sure on whether to use the View instance of the dialog to get a token rather than going straight to the root view (as in, android.R.id.content), but it does seem to fix the issues I'm experiencing here (on emulator and various devices).