### PR TITLE
Fixed crashes on pre-Lollipop

### DIFF
--- a/core/src/main/java/com/afollestad/materialdialogs/internal/MDTintHelper.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/internal/MDTintHelper.java
@@ -132,9 +132,14 @@ public class MDTintHelper {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             box.setButtonTintList(sl);
         } else {
-            Drawable checkVector = VectorDrawableCompat.create(box.getContext().getResources(),
+            Drawable checkDrawable = VectorDrawableCompat.create(box.getContext().getResources(),
                     R.drawable.abc_btn_check_material, null);
-            Drawable drawable = DrawableCompat.wrap(checkVector);
+            if (checkDrawable == null) {
+                // https://github.com/afollestad/material-dialogs/issues/1006
+                checkDrawable = ContextCompat.getDrawable(box.getContext(),
+                        R.drawable.abc_btn_check_material);
+            }
+            Drawable drawable = DrawableCompat.wrap(checkDrawable);
             DrawableCompat.setTintList(drawable, sl);
             box.setButtonDrawable(drawable);
         }

--- a/core/src/main/java/com/afollestad/materialdialogs/internal/MDTintHelper.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/internal/MDTintHelper.java
@@ -39,11 +39,17 @@ public class MDTintHelper {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             radioButton.setButtonTintList(sl);
         } else {
-            Drawable radioVector = VectorDrawableCompat.create(radioButton.getContext().getResources(),
+            Drawable radioDrawable = VectorDrawableCompat.create(radioButton.getContext().getResources(),
                     R.drawable.abc_btn_radio_material, null);
-            Drawable d = DrawableCompat.wrap(radioVector);
-            DrawableCompat.setTintList(d, sl);
-            radioButton.setButtonDrawable(d);
+            if (radioDrawable == null) {
+                // https://github.com/afollestad/material-dialogs/issues/1006
+                // Trying to load this resource as normal drawable
+                radioDrawable = ContextCompat.getDrawable(radioButton.getContext(),
+                        R.drawable.abc_btn_radio_material);
+            }
+            Drawable drawable = DrawableCompat.wrap(radioDrawable);
+            DrawableCompat.setTintList(drawable, sl);
+            radioButton.setButtonDrawable(drawable);
         }
     }
 
@@ -136,6 +142,7 @@ public class MDTintHelper {
                     R.drawable.abc_btn_check_material, null);
             if (checkDrawable == null) {
                 // https://github.com/afollestad/material-dialogs/issues/1006
+                // Trying to load this resource as normal drawable
                 checkDrawable = ContextCompat.getDrawable(box.getContext(),
                         R.drawable.abc_btn_check_material);
             }


### PR DESCRIPTION
This patch tries to load radio/check drawable as normal drawable when it's null, which fixed crashes on pre-Lollipop devices.