### PR TITLE
Update MaterialProgressBar to v1.1.7

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     compile "com.android.support:appcompat-v7:${SUPPORT_LIBRARY_VERSION}"
     compile "com.android.support:recyclerview-v7:${SUPPORT_LIBRARY_VERSION}"
     compile "com.android.support:support-annotations:${SUPPORT_LIBRARY_VERSION}"
-    compile "me.zhanghai.android.materialprogressbar:library:1.1.6"
+    compile "me.zhanghai.android.materialprogressbar:library:1.1.7"
 }
 
 apply from: 'https://raw.githubusercontent.com/afollestad/aidanfollestad.com/master/android-lib-release.gradle'


### PR DESCRIPTION
I've just released v1.1.7 which fixed the blurry progress bar on API < 18 (DreaminginCodeZH/MaterialProgressBar#30), so it would be nice to update to the latest version.