### PR TITLE
Call setProgress from UIThread

### DIFF
--- a/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -1666,7 +1666,6 @@ public class MaterialDialog extends DialogBase implements
             @Override
             public void run() {
                 if (mProgressLabel != null) {
-//                    final int percentage = (int) (((float) getCurrentProgress() / (float) getMaxProgress()) * 100f);
                     mProgressLabel.setText(mBuilder.progressPercentFormat.format(
                             (float) getCurrentProgress() / (float) getMaxProgress()));
                 }

--- a/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -8,7 +8,6 @@ import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
-import android.os.Handler;
 import android.support.annotation.ArrayRes;
 import android.support.annotation.AttrRes;
 import android.support.annotation.ColorInt;
@@ -91,7 +90,6 @@ public class MaterialDialog extends DialogBase implements
     @SuppressLint("InflateParams")
     protected MaterialDialog(Builder builder) {
         super(builder.context, DialogInit.getTheme(builder));
-        mHandler = new Handler();
         mBuilder = builder;
         final LayoutInflater inflater = LayoutInflater.from(builder.context);
         view = (MDRootLayout) inflater.inflate(DialogInit.getInflateLayout(builder), null);
@@ -1656,27 +1654,23 @@ public class MaterialDialog extends DialogBase implements
         setProgress(getCurrentProgress() + by);
     }
 
-    private final Handler mHandler;
-
+    @UiThread
     public final void setProgress(final int progress) {
         if (mBuilder.progress <= -2)
             throw new IllegalStateException("Cannot use setProgress() on this dialog.");
         mProgress.setProgress(progress);
-        mHandler.post(new Runnable() {
-            @Override
-            public void run() {
-                if (mProgressLabel != null) {
-                    mProgressLabel.setText(mBuilder.progressPercentFormat.format(
-                            (float) getCurrentProgress() / (float) getMaxProgress()));
-                }
-                if (mProgressMinMax != null) {
-                    mProgressMinMax.setText(String.format(mBuilder.progressNumberFormat,
-                            getCurrentProgress(), getMaxProgress()));
-                }
-            }
-        });
+
+        if (mProgressLabel != null) {
+            mProgressLabel.setText(mBuilder.progressPercentFormat.format(
+                    (float) getCurrentProgress() / (float) getMaxProgress()));
+        }
+        if (mProgressMinMax != null) {
+            mProgressMinMax.setText(String.format(mBuilder.progressNumberFormat,
+                    getCurrentProgress(), getMaxProgress()));
+        }
     }
 
+    @UiThread
     public final void setMaxProgress(final int max) {
         if (mBuilder.progress <= -2)
             throw new IllegalStateException("Cannot use setMaxProgress() on this dialog.");


### PR DESCRIPTION
In contrast to what was discussed in #505, I do not see why setProgress and setMaxProgress of ProgressBar should be thread safe.

Android UI elements are generally not thread safe and the [documentation of ProgressBar](https://developer.android.com/reference/android/widget/ProgressBar.html) does not state that the class or those functions are thread safe. Since we don't have a documented guarantee that those functions are thread safe, we need to assume that they are not. Even if the current implementation was thread safe, we don't know if it will keep that property in the next Android update.

Thus, if we like it or not, we must call ProgressBar.setProgress()/.setMaxProgress() from the ui thread (like [the official example](https://developer.android.com/reference/android/widget/ProgressBar.html) does). This could be done by Material Dialogs but for consistency we leave that issue for the application developer, who has more control about what is done on which thread.

To help app developers spot incorrect use of setProgress and setMaxProgress, this PR adds @UiThread annotations for the code analyzer in Android Studio.