### PR TITLE
Added icon tint option in MaterialSimpleListItem

### DIFF
--- a/commons/src/main/java/com/afollestad/materialdialogs/simplelist/MaterialSimpleListAdapter.java
+++ b/commons/src/main/java/com/afollestad/materialdialogs/simplelist/MaterialSimpleListAdapter.java
@@ -1,6 +1,9 @@
 package com.afollestad.materialdialogs.simplelist;
 
+import android.annotation.TargetApi;
+import android.content.res.ColorStateList;
 import android.graphics.PorterDuff;
+import android.os.Build;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -72,6 +75,10 @@ public class MaterialSimpleListAdapter extends RecyclerView.Adapter<MaterialSimp
                         item.getIconPadding(), item.getIconPadding());
                 holder.icon.getBackground().setColorFilter(item.getBackgroundColor(),
                         PorterDuff.Mode.SRC_ATOP);
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && item.getIconTint() != null) {
+                    holder.icon.setImageTintList(ColorStateList.valueOf(item.getIconTint()));
+                }
             } else {
                 holder.icon.setVisibility(View.GONE);
             }

--- a/commons/src/main/java/com/afollestad/materialdialogs/simplelist/MaterialSimpleListAdapter.java
+++ b/commons/src/main/java/com/afollestad/materialdialogs/simplelist/MaterialSimpleListAdapter.java
@@ -1,6 +1,5 @@
 package com.afollestad.materialdialogs.simplelist;
 
-import android.annotation.TargetApi;
 import android.content.res.ColorStateList;
 import android.graphics.PorterDuff;
 import android.os.Build;

--- a/commons/src/main/java/com/afollestad/materialdialogs/simplelist/MaterialSimpleListItem.java
+++ b/commons/src/main/java/com/afollestad/materialdialogs/simplelist/MaterialSimpleListItem.java
@@ -93,7 +93,6 @@ public class MaterialSimpleListItem {
             return this;
         }
 
-        @TargetApi(21)
         public Builder iconPaddingRes(@DimenRes int paddingRes) {
             return iconPadding(context.getResources().getDimensionPixelSize(paddingRes));
         }
@@ -108,6 +107,7 @@ public class MaterialSimpleListItem {
             return iconTintColor(DialogUtils.resolveColor(context, colorAttr));
         }
 
+        @TargetApi(21)
         public Builder iconTintColor(@ColorInt int color) {
             iconTint = color;
             return this;

--- a/commons/src/main/java/com/afollestad/materialdialogs/simplelist/MaterialSimpleListItem.java
+++ b/commons/src/main/java/com/afollestad/materialdialogs/simplelist/MaterialSimpleListItem.java
@@ -2,7 +2,6 @@ package com.afollestad.materialdialogs.simplelist;
 
 import android.annotation.TargetApi;
 import android.content.Context;
-import android.content.res.Resources;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.AttrRes;
@@ -14,13 +13,9 @@ import android.support.annotation.IntRange;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.v4.content.ContextCompat;
-import android.support.v4.content.res.ResourcesCompat;
 import android.util.TypedValue;
 
-import com.afollestad.materialdialogs.commons.R;
 import com.afollestad.materialdialogs.util.DialogUtils;
-
-import static android.support.v4.content.res.ResourcesCompat.getColor;
 
 /**
  * @author Aidan Follestad (afollestad)

--- a/commons/src/main/java/com/afollestad/materialdialogs/simplelist/MaterialSimpleListItem.java
+++ b/commons/src/main/java/com/afollestad/materialdialogs/simplelist/MaterialSimpleListItem.java
@@ -1,6 +1,8 @@
 package com.afollestad.materialdialogs.simplelist;
 
+import android.annotation.TargetApi;
 import android.content.Context;
+import android.content.res.Resources;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.AttrRes;
@@ -12,9 +14,13 @@ import android.support.annotation.IntRange;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.v4.content.ContextCompat;
+import android.support.v4.content.res.ResourcesCompat;
 import android.util.TypedValue;
 
+import com.afollestad.materialdialogs.commons.R;
 import com.afollestad.materialdialogs.util.DialogUtils;
+
+import static android.support.v4.content.res.ResourcesCompat.getColor;
 
 /**
  * @author Aidan Follestad (afollestad)
@@ -48,6 +54,9 @@ public class MaterialSimpleListItem {
         return builder.id;
     }
 
+    @ColorInt
+    public Integer getIconTint() { return builder.iconTint; }
+
     @Nullable
     public Object getTag() {
         return builder.tag;
@@ -59,6 +68,7 @@ public class MaterialSimpleListItem {
         protected Drawable icon;
         protected CharSequence content;
         protected int iconPadding;
+        protected Integer iconTint;
         protected int backgroundColor;
         protected long id;
         protected Object tag;
@@ -88,8 +98,24 @@ public class MaterialSimpleListItem {
             return this;
         }
 
+        @TargetApi(21)
         public Builder iconPaddingRes(@DimenRes int paddingRes) {
             return iconPadding(context.getResources().getDimensionPixelSize(paddingRes));
+        }
+
+        @TargetApi(21)
+        public Builder iconTintRes(@ColorRes int colorRes) {
+            return iconTintColor(DialogUtils.getColor(context, colorRes));
+        }
+
+        @TargetApi(21)
+        public Builder iconTintAttr(@AttrRes int colorAttr) {
+            return iconTintColor(DialogUtils.resolveColor(context, colorAttr));
+        }
+
+        public Builder iconTintColor(@ColorInt int color) {
+            iconTint = color;
+            return this;
         }
 
         public Builder content(CharSequence content) {

--- a/sample/src/main/java/com/afollestad/materialdialogssample/MainActivity.java
+++ b/sample/src/main/java/com/afollestad/materialdialogssample/MainActivity.java
@@ -416,6 +416,7 @@ public class MainActivity extends AppCompatActivity implements
         adapter.add(new MaterialSimpleListItem.Builder(this)
                 .content("user02@gmail.com")
                 .icon(R.drawable.ic_account_circle)
+                .iconTintColor(Color.RED)
                 .backgroundColor(Color.WHITE)
                 .build());
         adapter.add(new MaterialSimpleListItem.Builder(this)


### PR DESCRIPTION
Added code to implement icon tint from color, resource or attribute in list items (this option is available with API 21+).

Updated simple list example to show different icon color on LOLLIPOP and more recent devices

![screenshot_1485208808](https://cloud.githubusercontent.com/assets/22953640/22224684/c90055c0-e1bf-11e6-98ae-90e2f540df9f.png)
