### PR TITLE
Allow list dialog items.size() = 0 rather than not initializing builder.items

### DIFF
--- a/core/src/main/java/com/afollestad/materialdialogs/DialogInit.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/DialogInit.java
@@ -57,7 +57,7 @@ class DialogInit {
     static int getInflateLayout(MaterialDialog.Builder builder) {
         if (builder.customView != null) {
             return R.layout.md_dialog_custom;
-        } else if (builder.items != null && builder.items.size() >= 0 || builder.adapter != null) {
+        } else if (builder.items != null || builder.adapter != null) {
             if (builder.checkBoxPrompt != null)
                 return R.layout.md_dialog_list_check;
             return R.layout.md_dialog_list;

--- a/core/src/main/java/com/afollestad/materialdialogs/DialogInit.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/DialogInit.java
@@ -57,7 +57,7 @@ class DialogInit {
     static int getInflateLayout(MaterialDialog.Builder builder) {
         if (builder.customView != null) {
             return R.layout.md_dialog_custom;
-        } else if (builder.items != null && builder.items.size() > 0 || builder.adapter != null) {
+        } else if (builder.items != null && builder.items.size() >= 0 || builder.adapter != null) {
             if (builder.checkBoxPrompt != null)
                 return R.layout.md_dialog_list_check;
             return R.layout.md_dialog_list;

--- a/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -766,6 +766,8 @@ public class MaterialDialog extends DialogBase implements
                     i++;
                 }
                 items(array);
+            }else if(collection.size()==0){
+                items = new ArrayList<>();
             }
             return this;
         }

--- a/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -766,7 +766,7 @@ public class MaterialDialog extends DialogBase implements
                     i++;
                 }
                 items(array);
-            }else if(collection.size()==0){
+            } else if (collection.size() == 0) {
                 items = new ArrayList<>();
             }
             return this;


### PR DESCRIPTION
Sometimes we need to create a list dialog (SingleChoice/ MultiChoice) with no default items in it. Like "BASIC LIST (LONG PRESS)" in sample app, we can allow users to add items manually. If we write the following code
`List<String> list = new ArrayList<>();
MaterialDialog.Builder(this).items(list).show();`
then builder.items will not initialized ,and we will get a null object if we call dialog.getItems() method later.
In this pr, I try to initialize builder.items as a List with no elements, and dialog.getItems() will not return null then.
