### PR TITLE
Fixed issue with html on AboutDialog.java

### DIFF
--- a/sample/src/main/java/com/afollestad/materialdialogssample/AboutDialog.java
+++ b/sample/src/main/java/com/afollestad/materialdialogssample/AboutDialog.java
@@ -24,8 +24,18 @@ public class AboutDialog extends DialogFragment {
         return new MaterialDialog.Builder(getActivity())
                 .title(R.string.about)
                 .positiveText(R.string.dismiss)
-                .content(R.string.about_body)
+                 .content(fromHtml(getString(R.string.about_body)))
                 .contentLineSpacing(1.6f)
                 .build();
+    }
+    @SuppressWarnings("deprecation")
+    public static Spanned fromHtml(String html){
+        Spanned result;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+            result = Html.fromHtml(html,Html.FROM_HTML_MODE_LEGACY);
+        } else {
+            result = Html.fromHtml(html);
+        }
+        return result;
     }
 }


### PR DESCRIPTION
I opened an issue, like advised in some other projects, #1290. 

Now, here is my fix. it uses the deprecated method for older versions of android (tested on Samsung Galaxy Nexus (API 18)), and uses the new method for android N and higher (tested on ZTE Axon 7 (API 24)).