### PR TITLE
Fix issue when selecting a Folder

### DIFF
--- a/commons/src/main/java/com/afollestad/materialdialogs/folderselector/FolderChooserDialog.java
+++ b/commons/src/main/java/com/afollestad/materialdialogs/folderselector/FolderChooserDialog.java
@@ -64,8 +64,8 @@ public class FolderChooserDialog extends DialogFragment implements MaterialDialo
         if (canGoUp) {
             results[0] = getBuilder().goUpLabel;
         }
-        for (int i = canGoUp ? 1 : 0; i < parentContents.length; i++) {
-            results[i] = parentContents[i].getName();
+        for (int i = 0; i < parentContents.length; i++) {
+            results[canGoUp ? i + 1 : i] = parentContents[i].getName();
         }
         return results;
     }


### PR DESCRIPTION
Fix #1288

Issue related to this code, introduced in [this commit](https://github.com/afollestad/material-dialogs/commit/8e5ddffcc90b360b2e1f1c96e7b4a82c28462602).
```Java
for (int i = canGoUp ? 1 : 0; i < parentContents.length; i++) {
    results[i] = parentContents[i].getName();
}
```

When `canGoUp` is `true`: `results` must start at `1` (because `results[0]` is the "..." or any other label), but `parentContents` must start at `0`. Otherwise `n+1` folder will be selected instead of `n`. 