### PR TITLE
Fix crash with Objects class affecting API < 19

### DIFF
--- a/commons/src/main/java/com/afollestad/materialdialogs/folderselector/FolderChooserDialog.java
+++ b/commons/src/main/java/com/afollestad/materialdialogs/folderselector/FolderChooserDialog.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * @author Aidan Follestad (afollestad)
@@ -132,7 +131,7 @@ public class FolderChooserDialog extends DialogFragment implements MaterialDialo
                 }
             });
         }
-        if (Objects.equals(getBuilder().initialPath, "/")) {
+        if (getBuilder().initialPath.equals("/")) {
             canGoUp = false;
         }
         return builder.build();


### PR DESCRIPTION
Fix #1300

--------

Critical bug when using `FolderChooserDialog` on devices with API < 19. An update to the commons module should be released as soon as possible.

See #1300 for more details.