### PR TITLE
add setFocus Method for negative/neutral/positive buttons on material…

### DIFF
--- a/core/src/main/java/com/afollestad/materialdialogs/DialogInit.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/DialogInit.java
@@ -138,6 +138,23 @@ class DialogInit {
         dialog.neutralButton.setVisibility(builder.neutralText != null ? View.VISIBLE : View.GONE);
         dialog.negativeButton.setVisibility(builder.negativeText != null ? View.VISIBLE : View.GONE);
 
+        // Set up the focus of action buttons
+        dialog.positiveButton.setFocusable(true);
+        dialog.positiveButton.setFocusableInTouchMode(true);
+        dialog.neutralButton.setFocusable(true);
+        dialog.neutralButton.setFocusableInTouchMode(true);
+        dialog.negativeButton.setFocusable(true);
+        dialog.negativeButton.setFocusableInTouchMode(true);
+        if (builder.positiveFocus){
+            dialog.positiveButton.requestFocus();
+        }
+        if (builder.neutralFocus){
+            dialog.neutralButton.requestFocus();
+        }
+        if (builder.negativeFocus){
+            dialog.negativeButton.requestFocus();
+        }
+
         // Setup icon
         if (builder.icon != null) {
             dialog.icon.setVisibility(View.VISIBLE);

--- a/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -453,6 +453,9 @@ public class MaterialDialog extends DialogBase implements
         protected CharSequence positiveText;
         protected CharSequence neutralText;
         protected CharSequence negativeText;
+        protected boolean positiveFocus;
+        protected boolean neutralFocus;
+        protected boolean negativeFocus;
         protected View customView;
         protected int widgetColor;
         protected ColorStateList choiceWidgetColor;
@@ -997,6 +1000,11 @@ public class MaterialDialog extends DialogBase implements
             return this;
         }
 
+        public Builder positiveFocus(boolean isFocusedDefault){
+            this.positiveFocus = isFocusedDefault;
+            return this;
+        }
+
         public Builder neutralText(@StringRes int neutralRes) {
             if (neutralRes == 0) return this;
             return neutralText(this.context.getText(neutralRes));
@@ -1035,6 +1043,11 @@ public class MaterialDialog extends DialogBase implements
             return this;
         }
 
+        public Builder negativeFocus(boolean isFocusedDefault){
+            this.negativeFocus = isFocusedDefault;
+            return this;
+        }
+
         public Builder neutralColor(@ColorInt int color) {
             return neutralColor(DialogUtils.getActionTextStateList(context, color));
         }
@@ -1050,6 +1063,11 @@ public class MaterialDialog extends DialogBase implements
         public Builder neutralColor(@NonNull ColorStateList colorStateList) {
             this.neutralColor = colorStateList;
             this.neutralColorSet = true;
+            return this;
+        }
+
+        public Builder neutralFocus(boolean isFocusedDefault){
+            this.neutralFocus = isFocusedDefault;
             return this;
         }
 


### PR DESCRIPTION
Hi,
For fix: [Issue 1309](https://github.com/afollestad/material-dialogs/issues/1309)
I add one method by button for set focus on.
For remote or keyboard or gamepad we need have focus setted to button when is a simple two choice alert.

Please comment any improvement ;)
Thanks ;)