### PR TITLE
Update Android Gradle plugin to 2.3.2

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,7 @@ ext.versions = [
         buildTools: '25.0.3',
         publishVersion: '0.9.4.5',
         publishVersionCode: 175,
-        gradlePlugin: '2.3.0',
+        gradlePlugin: '2.3.2',
 
         supportLib: '25.3.1',
         mdProgressBar: '1.4.1',


### PR DESCRIPTION
[Android Studio 2.3.2 is now available in the stable channel](https://androidstudio.googleblog.com/2017/05/android-studio-232-is-now-available-in.html) and the Android Gradle plugin has been updated to `2.3.2` as well.