### PR TITLE
Allow Color, File & Folder Dialogs to be hosted in Fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1130,7 +1130,7 @@ new ColorChooserDialog.Builder(this, R.string.color_palette)
     .backButton(R.string.md_back_label)  // changes label of the back button
     .preselect(accent ? accentPreselect : primaryPreselect)  // optionally preselects a color
     .dynamicButtonColor(true)  // defaults to true, false will disable changing action buttons' color to currently selected color
-    .show(getSupportFragmentManager());
+    .show(this); // an AppCompatActivity which implements ColorCallback
 ```
 
 The Activity/Fragment you show the dialog in must implement `ColorCallback`:
@@ -1163,7 +1163,7 @@ int[][] secondary = new int[][] {
 new ColorChooserDialog.Builder(this, R.string.color_palette)
     .titleSub(R.string.colors)
     .customColors(primary, secondary)
-    .show(getSupportFragmentManager());
+    .show(this);
 ```
 
 The first parameter for primary colors can also take an array resource (`R.array.colors`), which can be
@@ -1194,7 +1194,7 @@ new ColorChooserDialog.Builder(this, R.string.color_palette)
     .allowUserColorInput(false)
     .customButton(R.string.md_custom_label)
     .presetsButton(R.string.md_presets_label)
-    .show(getSupportFragmentManager());
+    .show(this);
 ```
 
 If you want the user to be able to input a custom color, but don't want them to be able to change transparency (alpha):
@@ -1204,7 +1204,7 @@ new ColorChooserDialog.Builder(this, R.string.color_palette)
     .allowUserColorInputAlpha(false)
     .customButton(R.string.md_custom_label)
     .presetsButton(R.string.md_presets_label)
-    .show(getSupportFragmentManager());
+    .show(this);
 ```
 
 ---
@@ -1236,7 +1236,7 @@ new FileChooserDialog.Builder(this)
     .extensionsFilter(".png", ".jpg") // Optional extension filter, will override mimeType()
     .tag("optional-identifier")
     .goUpLabel("Up") // custom go up label, default label is "..."
-    .show(getSupportFragmentManager());
+    .show(this); // an AppCompatActivity which implements ColorCallback
 ```
 
 The Activity/Fragment you show the dialog in must implement `FileCallback`:
@@ -1267,7 +1267,7 @@ new FolderChooserDialog.Builder(this)
     .initialPath("/sdcard/Download")  // changes initial path, defaults to external storage directory
     .tag("optional-identifier")
     .goUpLabel("Up") // custom go up label, default label is "..."
-    .show(getSupportFragmentManager());
+    .show(this);
 ```
 
 The Activity/Fragment you show the dialog in must implement `FolderCallback`:
@@ -1295,7 +1295,7 @@ new FolderChooserDialog.Builder(this)
     .initialPath("/sdcard/Download")  // changes initial path, defaults to external storage directory
     .tag("optional-identifier")
     .allowNewFolder(true, R.string.new_folder)  // pass 0 in the second parameter to use default button label
-    .show(getSupportFragmentManager());
+    .show(this);
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -1121,7 +1121,7 @@ MaterialDialog dialog = new MaterialDialog.Builder(this)
 The Builder is used like this:
 
 ```java
-// Pass AppCompatActivity which implements ColorCallback, along with the title of the dialog
+// Pass a context, along with the title of the dialog
 new ColorChooserDialog.Builder(this, R.string.color_palette)
     .titleSub(R.string.colors)  // title of dialog when viewing shades of a color
     .accentMode(accent)  // when true, will display accent palette instead of primary palette
@@ -1130,10 +1130,10 @@ new ColorChooserDialog.Builder(this, R.string.color_palette)
     .backButton(R.string.md_back_label)  // changes label of the back button
     .preselect(accent ? accentPreselect : primaryPreselect)  // optionally preselects a color
     .dynamicButtonColor(true)  // defaults to true, false will disable changing action buttons' color to currently selected color
-    .show();
+    .show(getSupportFragmentManager());
 ```
 
-The Activity you show the dialog in must implement `ColorCallback`:
+The Activity/Fragment you show the dialog in must implement `ColorCallback`:
 
 ```java
 public class MyActivity implements ColorChooserDialog.ColorCallback {
@@ -1163,7 +1163,7 @@ int[][] secondary = new int[][] {
 new ColorChooserDialog.Builder(this, R.string.color_palette)
     .titleSub(R.string.colors)
     .customColors(primary, secondary)
-    .show();
+    .show(getSupportFragmentManager());
 ```
 
 The first parameter for primary colors can also take an array resource (`R.array.colors`), which can be
@@ -1172,16 +1172,16 @@ for top level colors.
 
 ## Finding Visible Dialogs
 
-Since the `ColorChooserDialog` is a `DialogFragment`, it attaches to your Activity through its `FragmentManager`.
+Since the `ColorChooserDialog` is a `DialogFragment`, it attaches to your Activity/Fragment through its `FragmentManager`.
 `ColorChooserDialog` has a utility method called `findVisible(AppCompatActivity, String)` that will
 find a visible color chooser if any is visible:
 
 ```java
-ColorChooserDialog primary = ColorChooserDialog.findVisible(this, ColorChooserDialog.TAG_PRIMARY);
+ColorChooserDialog primary = ColorChooserDialog.findVisible(getSupportFragmentManager(), ColorChooserDialog.TAG_PRIMARY);
 
-ColorChooserDialog accent = ColorChooserDialog.findVisible(this, ColorChooserDialog.TAG_ACCENT);
+ColorChooserDialog accent = ColorChooserDialog.findVisible(getSupportFragmentManager(), ColorChooserDialog.TAG_ACCENT);
 
-ColorChooserDialog custom = ColorChooserDialog.findVisible(this, ColorChooserDialog.TAG_CUSTOM);
+ColorChooserDialog custom = ColorChooserDialog.findVisible(getSupportFragmentManager(), ColorChooserDialog.TAG_CUSTOM);
 ```
 
 ## User Color Input
@@ -1194,7 +1194,7 @@ new ColorChooserDialog.Builder(this, R.string.color_palette)
     .allowUserColorInput(false)
     .customButton(R.string.md_custom_label)
     .presetsButton(R.string.md_presets_label)
-    .show();
+    .show(getSupportFragmentManager());
 ```
 
 If you want the user to be able to input a custom color, but don't want them to be able to change transparency (alpha):
@@ -1204,7 +1204,7 @@ new ColorChooserDialog.Builder(this, R.string.color_palette)
     .allowUserColorInputAlpha(false)
     .customButton(R.string.md_custom_label)
     .presetsButton(R.string.md_presets_label)
-    .show();
+    .show(getSupportFragmentManager());
 ```
 
 ---
@@ -1230,17 +1230,16 @@ app:useStockLayout="true"
 The Builder is used like this:
 
 ```java
-// Pass AppCompatActivity which implements FileCallback
 new FileChooserDialog.Builder(this)
     .initialPath("/sdcard/Download")  // changes initial path, defaults to external storage directory
     .mimeType("image/*") // Optional MIME type filter
     .extensionsFilter(".png", ".jpg") // Optional extension filter, will override mimeType()
     .tag("optional-identifier")
     .goUpLabel("Up") // custom go up label, default label is "..."
-    .show();
+    .show(getSupportFragmentManager());
 ```
 
-The Activity you show the dialog in must implement `FileCallback`:
+The Activity/Fragment you show the dialog in must implement `FileCallback`:
 
 ```java
 public class MyActivity implements FileChooserDialog.FileCallback {
@@ -1268,10 +1267,10 @@ new FolderChooserDialog.Builder(this)
     .initialPath("/sdcard/Download")  // changes initial path, defaults to external storage directory
     .tag("optional-identifier")
     .goUpLabel("Up") // custom go up label, default label is "..."
-    .show();
+    .show(getSupportFragmentManager());
 ```
 
-The Activity you show the dialog in must implement `FolderCallback`:
+The Activity/Fragment you show the dialog in must implement `FolderCallback`:
 
 ```java
 public class MyActivity implements FolderChooserDialog.FolderCallback {
@@ -1296,7 +1295,7 @@ new FolderChooserDialog.Builder(this)
     .initialPath("/sdcard/Download")  // changes initial path, defaults to external storage directory
     .tag("optional-identifier")
     .allowNewFolder(true, R.string.new_folder)  // pass 0 in the second parameter to use default button label
-    .show();
+    .show(getSupportFragmentManager());
 ```
 
 ---

--- a/commons/src/main/java/com/afollestad/materialdialogs/color/ColorChooserDialog.java
+++ b/commons/src/main/java/com/afollestad/materialdialogs/color/ColorChooserDialog.java
@@ -15,6 +15,7 @@ import android.support.annotation.StringDef;
 import android.support.annotation.StringRes;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.content.res.ResourcesCompat;
 import android.text.Editable;
@@ -596,6 +597,11 @@ public class ColorChooserDialog extends DialogFragment
     return this;
   }
 
+  @NonNull
+  public ColorChooserDialog show(FragmentActivity fragmentActivity) {
+    return show(fragmentActivity.getSupportFragmentManager());
+  }
+
   @Retention(RetentionPolicy.SOURCE)
   @StringDef({TAG_PRIMARY, TAG_ACCENT, TAG_CUSTOM})
   public @interface ColorChooserTag {}
@@ -750,6 +756,11 @@ public class ColorChooserDialog extends DialogFragment
       ColorChooserDialog dialog = build();
       dialog.show(fragmentManager);
       return dialog;
+    }
+
+    @NonNull
+    public ColorChooserDialog show(FragmentActivity fragmentActivity) {
+      return show(fragmentActivity.getSupportFragmentManager());
     }
   }
 

--- a/commons/src/main/java/com/afollestad/materialdialogs/color/ColorChooserDialog.java
+++ b/commons/src/main/java/com/afollestad/materialdialogs/color/ColorChooserDialog.java
@@ -71,7 +71,7 @@ public class ColorChooserDialog extends DialogFragment
 
   @Nullable
   public static ColorChooserDialog findVisible(
-          @NonNull FragmentManager fragmentManager, @ColorChooserTag String tag) {
+      @NonNull FragmentManager fragmentManager, @ColorChooserTag String tag) {
     Fragment frag = fragmentManager.findFragmentByTag(tag);
     if (frag != null && frag instanceof ColorChooserDialog) {
       return (ColorChooserDialog) frag;
@@ -110,13 +110,13 @@ public class ColorChooserDialog extends DialogFragment
   @Override
   public void onAttach(Context context) {
     super.onAttach(context);
-    if (getActivity() instanceof ColorCallback){
+    if (getActivity() instanceof ColorCallback) {
       callback = (ColorCallback) getActivity();
-    } else if (getParentFragment() instanceof ColorCallback){
+    } else if (getParentFragment() instanceof ColorCallback) {
       callback = (ColorCallback) getParentFragment();
     } else {
       throw new IllegalStateException(
-              "ColorChooserDialog needs to be shown from an Activity/Fragment implementing ColorCallback.");
+          "ColorChooserDialog needs to be shown from an Activity/Fragment implementing ColorCallback.");
     }
   }
 

--- a/commons/src/main/java/com/afollestad/materialdialogs/color/ColorChooserDialog.java
+++ b/commons/src/main/java/com/afollestad/materialdialogs/color/ColorChooserDialog.java
@@ -1,8 +1,8 @@
 package com.afollestad.materialdialogs.color;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
 import android.app.Dialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.graphics.Color;
 import android.os.Build;
@@ -15,8 +15,8 @@ import android.support.annotation.StringDef;
 import android.support.annotation.StringRes;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
 import android.support.v4.content.res.ResourcesCompat;
-import android.support.v7.app.AppCompatActivity;
 import android.text.Editable;
 import android.text.InputFilter;
 import android.text.TextWatcher;
@@ -70,8 +70,8 @@ public class ColorChooserDialog extends DialogFragment
 
   @Nullable
   public static ColorChooserDialog findVisible(
-      @NonNull AppCompatActivity context, @ColorChooserTag String tag) {
-    Fragment frag = context.getSupportFragmentManager().findFragmentByTag(tag);
+          @NonNull FragmentManager fragmentManager, @ColorChooserTag String tag) {
+    Fragment frag = fragmentManager.findFragmentByTag(tag);
     if (frag != null && frag instanceof ColorChooserDialog) {
       return (ColorChooserDialog) frag;
     }
@@ -107,13 +107,16 @@ public class ColorChooserDialog extends DialogFragment
   }
 
   @Override
-  public void onAttach(Activity activity) {
-    super.onAttach(activity);
-    if (!(activity instanceof ColorCallback)) {
+  public void onAttach(Context context) {
+    super.onAttach(context);
+    if (getActivity() instanceof ColorCallback){
+      callback = (ColorCallback) getActivity();
+    } else if (getParentFragment() instanceof ColorCallback){
+      callback = (ColorCallback) getParentFragment();
+    } else {
       throw new IllegalStateException(
-          "ColorChooserDialog needs to be shown from an Activity implementing ColorCallback.");
+              "ColorChooserDialog needs to be shown from an Activity/Fragment implementing ColorCallback.");
     }
-    callback = (ColorCallback) activity;
   }
 
   private boolean isInSub() {
@@ -569,16 +572,16 @@ public class ColorChooserDialog extends DialogFragment
     return (Builder) getArguments().getSerializable("builder");
   }
 
-  private void dismissIfNecessary(AppCompatActivity context, String tag) {
-    Fragment frag = context.getSupportFragmentManager().findFragmentByTag(tag);
+  private void dismissIfNecessary(FragmentManager fragmentManager, String tag) {
+    Fragment frag = fragmentManager.findFragmentByTag(tag);
     if (frag != null) {
       ((DialogFragment) frag).dismiss();
-      context.getSupportFragmentManager().beginTransaction().remove(frag).commit();
+      fragmentManager.beginTransaction().remove(frag).commit();
     }
   }
 
   @NonNull
-  public ColorChooserDialog show(AppCompatActivity context) {
+  public ColorChooserDialog show(FragmentManager fragmentManager) {
     String tag;
     Builder builder = getBuilder();
     if (builder.colorsTop != null) {
@@ -588,8 +591,8 @@ public class ColorChooserDialog extends DialogFragment
     } else {
       tag = TAG_PRIMARY;
     }
-    dismissIfNecessary(context, tag);
-    show(context.getSupportFragmentManager(), tag);
+    dismissIfNecessary(fragmentManager, tag);
+    show(fragmentManager, tag);
     return this;
   }
 
@@ -606,7 +609,7 @@ public class ColorChooserDialog extends DialogFragment
 
   public static class Builder implements Serializable {
 
-    @NonNull final transient AppCompatActivity context;
+    @NonNull final transient Context context;
     @Nullable String mediumFont;
     @Nullable String regularFont;
     @StringRes final int title;
@@ -628,8 +631,7 @@ public class ColorChooserDialog extends DialogFragment
     boolean allowUserCustomAlpha = true;
     boolean setPreselectionColor = false;
 
-    public <ActivityType extends AppCompatActivity & ColorCallback> Builder(
-        @NonNull ActivityType context, @StringRes int title) {
+    public Builder(@NonNull Context context, @StringRes int title) {
       this.context = context;
       this.title = title;
     }
@@ -744,9 +746,9 @@ public class ColorChooserDialog extends DialogFragment
     }
 
     @NonNull
-    public ColorChooserDialog show() {
+    public ColorChooserDialog show(FragmentManager fragmentManager) {
       ColorChooserDialog dialog = build();
-      dialog.show(context);
+      dialog.show(fragmentManager);
       return dialog;
     }
   }

--- a/commons/src/main/java/com/afollestad/materialdialogs/folderselector/FileChooserDialog.java
+++ b/commons/src/main/java/com/afollestad/materialdialogs/folderselector/FileChooserDialog.java
@@ -3,6 +3,7 @@ package com.afollestad.materialdialogs.folderselector;
 import android.Manifest;
 import android.app.Activity;
 import android.app.Dialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.pm.PackageManager;
 import android.os.Build;
@@ -14,8 +15,7 @@ import android.support.annotation.StringRes;
 import android.support.v13.app.ActivityCompat;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentActivity;
-import android.support.v7.app.AppCompatActivity;
+import android.support.v4.app.FragmentManager;
 import android.view.View;
 import android.webkit.MimeTypeMap;
 import com.afollestad.materialdialogs.DialogAction;
@@ -218,19 +218,32 @@ public class FileChooserDialog extends DialogFragment implements MaterialDialog.
   }
 
   @Override
+  public void onAttach(Context context) {
+    super.onAttach(context);
+    if (getActivity() instanceof FileCallback){
+      callback = (FileCallback) getActivity();
+    } else if (getParentFragment() instanceof FileCallback){
+      callback = (FileCallback) getParentFragment();
+    } else {
+      throw new IllegalStateException(
+              "FileChooserDialog needs to be shown from an Activity/Fragment implementing FileCallback.");
+    }
+  }
+
+  @Override
   public void onAttach(Activity activity) {
     super.onAttach(activity);
     callback = (FileCallback) activity;
   }
 
-  public void show(FragmentActivity context) {
+  public void show(FragmentManager fragmentManager) {
     final String tag = getBuilder().tag;
-    Fragment frag = context.getSupportFragmentManager().findFragmentByTag(tag);
+    Fragment frag = fragmentManager.findFragmentByTag(tag);
     if (frag != null) {
       ((DialogFragment) frag).dismiss();
-      context.getSupportFragmentManager().beginTransaction().remove(frag).commit();
+      fragmentManager.beginTransaction().remove(frag).commit();
     }
-    show(context.getSupportFragmentManager(), tag);
+    show(fragmentManager, tag);
   }
 
   @NonNull
@@ -253,7 +266,7 @@ public class FileChooserDialog extends DialogFragment implements MaterialDialog.
 
   public static class Builder implements Serializable {
 
-    @NonNull final transient AppCompatActivity context;
+    @NonNull final transient Context context;
     @StringRes int cancelButton;
     String initialPath;
     String mimeType;
@@ -263,8 +276,7 @@ public class FileChooserDialog extends DialogFragment implements MaterialDialog.
     @Nullable String mediumFont;
     @Nullable String regularFont;
 
-    public <ActivityType extends AppCompatActivity & FileCallback> Builder(
-        @NonNull ActivityType context) {
+    public Builder(@NonNull Context context) {
       this.context = context;
       cancelButton = android.R.string.cancel;
       initialPath = Environment.getExternalStorageDirectory().getAbsolutePath();
@@ -331,9 +343,9 @@ public class FileChooserDialog extends DialogFragment implements MaterialDialog.
     }
 
     @NonNull
-    public FileChooserDialog show() {
+    public FileChooserDialog show(FragmentManager fragmentManager) {
       FileChooserDialog dialog = build();
-      dialog.show(context);
+      dialog.show(fragmentManager);
       return dialog;
     }
   }

--- a/commons/src/main/java/com/afollestad/materialdialogs/folderselector/FileChooserDialog.java
+++ b/commons/src/main/java/com/afollestad/materialdialogs/folderselector/FileChooserDialog.java
@@ -220,13 +220,13 @@ public class FileChooserDialog extends DialogFragment implements MaterialDialog.
   @Override
   public void onAttach(Context context) {
     super.onAttach(context);
-    if (getActivity() instanceof FileCallback){
+    if (getActivity() instanceof FileCallback) {
       callback = (FileCallback) getActivity();
-    } else if (getParentFragment() instanceof FileCallback){
+    } else if (getParentFragment() instanceof FileCallback) {
       callback = (FileCallback) getParentFragment();
     } else {
       throw new IllegalStateException(
-              "FileChooserDialog needs to be shown from an Activity/Fragment implementing FileCallback.");
+          "FileChooserDialog needs to be shown from an Activity/Fragment implementing FileCallback.");
     }
   }
 

--- a/commons/src/main/java/com/afollestad/materialdialogs/folderselector/FileChooserDialog.java
+++ b/commons/src/main/java/com/afollestad/materialdialogs/folderselector/FileChooserDialog.java
@@ -1,7 +1,6 @@
 package com.afollestad.materialdialogs.folderselector;
 
 import android.Manifest;
-import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -15,6 +14,7 @@ import android.support.annotation.StringRes;
 import android.support.v13.app.ActivityCompat;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
 import android.view.View;
 import android.webkit.MimeTypeMap;
@@ -230,12 +230,6 @@ public class FileChooserDialog extends DialogFragment implements MaterialDialog.
     }
   }
 
-  @Override
-  public void onAttach(Activity activity) {
-    super.onAttach(activity);
-    callback = (FileCallback) activity;
-  }
-
   public void show(FragmentManager fragmentManager) {
     final String tag = getBuilder().tag;
     Fragment frag = fragmentManager.findFragmentByTag(tag);
@@ -244,6 +238,10 @@ public class FileChooserDialog extends DialogFragment implements MaterialDialog.
       fragmentManager.beginTransaction().remove(frag).commit();
     }
     show(fragmentManager, tag);
+  }
+
+  public void show(FragmentActivity fragmentActivity) {
+    show(fragmentActivity.getSupportFragmentManager());
   }
 
   @NonNull
@@ -347,6 +345,11 @@ public class FileChooserDialog extends DialogFragment implements MaterialDialog.
       FileChooserDialog dialog = build();
       dialog.show(fragmentManager);
       return dialog;
+    }
+
+    @NonNull
+    public FileChooserDialog show(FragmentActivity fragmentActivity) {
+      return show(fragmentActivity.getSupportFragmentManager());
     }
   }
 

--- a/commons/src/main/java/com/afollestad/materialdialogs/folderselector/FolderChooserDialog.java
+++ b/commons/src/main/java/com/afollestad/materialdialogs/folderselector/FolderChooserDialog.java
@@ -206,13 +206,13 @@ public class FolderChooserDialog extends DialogFragment implements MaterialDialo
   @Override
   public void onAttach(Context context) {
     super.onAttach(context);
-    if (getActivity() instanceof FolderCallback){
+    if (getActivity() instanceof FolderCallback) {
       callback = (FolderCallback) getActivity();
-    } else if (getParentFragment() instanceof FolderCallback){
+    } else if (getParentFragment() instanceof FolderCallback) {
       callback = (FolderCallback) getParentFragment();
     } else {
       throw new IllegalStateException(
-              "FolderChooserDialog needs to be shown from an Activity/Fragment implementing FolderCallback.");
+          "FolderChooserDialog needs to be shown from an Activity/Fragment implementing FolderCallback.");
     }
   }
 

--- a/commons/src/main/java/com/afollestad/materialdialogs/folderselector/FolderChooserDialog.java
+++ b/commons/src/main/java/com/afollestad/materialdialogs/folderselector/FolderChooserDialog.java
@@ -14,6 +14,7 @@ import android.support.annotation.StringRes;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
 import android.view.View;
 import android.widget.Toast;
@@ -215,6 +216,10 @@ public class FolderChooserDialog extends DialogFragment implements MaterialDialo
     }
   }
 
+  public void show(FragmentActivity fragmentActivity) {
+    show(fragmentActivity.getSupportFragmentManager());
+  }
+
   public void show(FragmentManager fragmentManager) {
     final String tag = getBuilder().tag;
     Fragment frag = fragmentManager.findFragmentByTag(tag);
@@ -326,6 +331,11 @@ public class FolderChooserDialog extends DialogFragment implements MaterialDialo
       FolderChooserDialog dialog = build();
       dialog.show(fragmentManager);
       return dialog;
+    }
+
+    @NonNull
+    public FolderChooserDialog show(FragmentActivity fragmentActivity) {
+      return show(fragmentActivity.getSupportFragmentManager());
     }
   }
 

--- a/sample/src/main/java/com/afollestad/materialdialogssample/MainActivity.java
+++ b/sample/src/main/java/com/afollestad/materialdialogssample/MainActivity.java
@@ -542,7 +542,7 @@ public class MainActivity extends AppCompatActivity
     new ColorChooserDialog.Builder(this, R.string.color_palette)
         .titleSub(R.string.colors)
         .preselect(primaryPreselect)
-        .show(getSupportFragmentManager());
+        .show(this);
   }
 
   @OnClick(R.id.colorChooser_accent)
@@ -551,7 +551,7 @@ public class MainActivity extends AppCompatActivity
         .titleSub(R.string.colors)
         .accentMode(true)
         .preselect(accentPreselect)
-        .show(getSupportFragmentManager());
+        .show(this);
   }
 
   @OnClick(R.id.colorChooser_customColors)
@@ -582,7 +582,7 @@ public class MainActivity extends AppCompatActivity
         .titleSub(R.string.colors)
         .preselect(primaryPreselect)
         .customColors(R.array.custom_colors, subColors)
-        .show(getSupportFragmentManager());
+        .show(this);
   }
 
   @OnClick(R.id.colorChooser_customColorsNoSub)
@@ -591,7 +591,7 @@ public class MainActivity extends AppCompatActivity
         .titleSub(R.string.colors)
         .preselect(primaryPreselect)
         .customColors(R.array.custom_colors, null)
-        .show(getSupportFragmentManager());
+        .show(this);
   }
 
   // Receives callback from color chooser dialog
@@ -668,7 +668,7 @@ public class MainActivity extends AppCompatActivity
           STORAGE_PERMISSION_RC);
       return;
     }
-    new FileChooserDialog.Builder(this).show(getSupportFragmentManager());
+    new FileChooserDialog.Builder(this).show(this);
   }
 
   @Override
@@ -697,7 +697,7 @@ public class MainActivity extends AppCompatActivity
     new FolderChooserDialog.Builder(MainActivity.this)
         .chooseButton(R.string.md_choose_label)
         .allowNewFolder(true, 0)
-        .show(getSupportFragmentManager());
+        .show(this);
   }
 
   @Override

--- a/sample/src/main/java/com/afollestad/materialdialogssample/MainActivity.java
+++ b/sample/src/main/java/com/afollestad/materialdialogssample/MainActivity.java
@@ -542,7 +542,7 @@ public class MainActivity extends AppCompatActivity
     new ColorChooserDialog.Builder(this, R.string.color_palette)
         .titleSub(R.string.colors)
         .preselect(primaryPreselect)
-        .show();
+        .show(getSupportFragmentManager());
   }
 
   @OnClick(R.id.colorChooser_accent)
@@ -551,7 +551,7 @@ public class MainActivity extends AppCompatActivity
         .titleSub(R.string.colors)
         .accentMode(true)
         .preselect(accentPreselect)
-        .show();
+        .show(getSupportFragmentManager());
   }
 
   @OnClick(R.id.colorChooser_customColors)
@@ -582,7 +582,7 @@ public class MainActivity extends AppCompatActivity
         .titleSub(R.string.colors)
         .preselect(primaryPreselect)
         .customColors(R.array.custom_colors, subColors)
-        .show();
+        .show(getSupportFragmentManager());
   }
 
   @OnClick(R.id.colorChooser_customColorsNoSub)
@@ -591,7 +591,7 @@ public class MainActivity extends AppCompatActivity
         .titleSub(R.string.colors)
         .preselect(primaryPreselect)
         .customColors(R.array.custom_colors, null)
-        .show();
+        .show(getSupportFragmentManager());
   }
 
   // Receives callback from color chooser dialog
@@ -668,7 +668,7 @@ public class MainActivity extends AppCompatActivity
           STORAGE_PERMISSION_RC);
       return;
     }
-    new FileChooserDialog.Builder(this).show();
+    new FileChooserDialog.Builder(this).show(getSupportFragmentManager());
   }
 
   @Override
@@ -697,7 +697,7 @@ public class MainActivity extends AppCompatActivity
     new FolderChooserDialog.Builder(MainActivity.this)
         .chooseButton(R.string.md_choose_label)
         .allowNewFolder(true, 0)
-        .show();
+        .show(getSupportFragmentManager());
   }
 
   @Override


### PR DESCRIPTION
The ColorDialog, FileChooserDialog & FolderChooserDialog can now be
hosted in a Fragment (rather than just an Activity) and the Fragment
itself can implement the Dialog's callbacks.

Note: The `Dialog.show()` method now requires the FragmentManager to be
passed in from the caller, as we can no longer cast the Context to an
Activity to get a reference to the FragmentManager.

This is a relatively straight-forward change that gives us flexibility to handle the dialog callbacks from a fragment rather than being forced to implement the callback by the parent activity.