### PR TITLE
Add support for multi colors for list item dialog

### DIFF
--- a/commons/src/main/java/com/afollestad/materialdialogs/simplelist/MaterialSimpleListAdapter.java
+++ b/commons/src/main/java/com/afollestad/materialdialogs/simplelist/MaterialSimpleListAdapter.java
@@ -77,7 +77,7 @@ public class MaterialSimpleListAdapter
       } else {
         holder.icon.setVisibility(View.GONE);
       }
-      holder.title.setTextColor(dialog.getBuilder().getItemColor());
+      holder.title.setTextColor(dialog.getBuilder().getItemColor(position));
       holder.title.setText(item.getContent());
       dialog.setTypeface(holder.title, dialog.getBuilder().getRegularFont());
     }

--- a/core/src/main/java/com/afollestad/materialdialogs/DefaultRvAdapter.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/DefaultRvAdapter.java
@@ -44,13 +44,13 @@ class DefaultRvAdapter extends RecyclerView.Adapter<DefaultRvAdapter.DefaultVH> 
   }
 
   @Override
-  public void onBindViewHolder(DefaultVH holder, int index) {
+  public void onBindViewHolder(DefaultVH holder, int position) {
     final View view = holder.itemView;
-    boolean disabled = DialogUtils.isIn(index, dialog.builder.disabledIndices);
+    boolean disabled = DialogUtils.isIn(position, dialog.builder.disabledIndices);
     int itemTextColor =
         disabled
-            ? DialogUtils.adjustAlpha(dialog.builder.itemColor, 0.4f)
-            : dialog.builder.itemColor;
+            ? DialogUtils.adjustAlpha(dialog.getBuilder().getItemColor(position), 0.4f)
+            : dialog.getBuilder().getItemColor(position);
     holder.itemView.setEnabled(!disabled);
 
     switch (dialog.listType) {
@@ -58,7 +58,7 @@ class DefaultRvAdapter extends RecyclerView.Adapter<DefaultRvAdapter.DefaultVH> 
         {
           @SuppressLint("CutPasteId")
           RadioButton radio = (RadioButton) holder.control;
-          boolean selected = dialog.builder.selectedIndex == index;
+          boolean selected = dialog.builder.selectedIndex == position;
           if (dialog.builder.choiceWidgetColor != null) {
             MDTintHelper.setTint(radio, dialog.builder.choiceWidgetColor);
           } else {
@@ -72,7 +72,7 @@ class DefaultRvAdapter extends RecyclerView.Adapter<DefaultRvAdapter.DefaultVH> 
         {
           @SuppressLint("CutPasteId")
           CheckBox checkbox = (CheckBox) holder.control;
-          boolean selected = dialog.selectedIndicesList.contains(index);
+          boolean selected = dialog.selectedIndicesList.contains(position);
           if (dialog.builder.choiceWidgetColor != null) {
             MDTintHelper.setTint(checkbox, dialog.builder.choiceWidgetColor);
           } else {
@@ -84,15 +84,15 @@ class DefaultRvAdapter extends RecyclerView.Adapter<DefaultRvAdapter.DefaultVH> 
         }
     }
 
-    holder.title.setText(dialog.builder.items.get(index));
+    holder.title.setText(dialog.builder.items.get(position));
     holder.title.setTextColor(itemTextColor);
     dialog.setTypeface(holder.title, dialog.builder.regularFont);
 
     setupGravity((ViewGroup) view);
 
     if (dialog.builder.itemIds != null) {
-      if (index < dialog.builder.itemIds.length) {
-        view.setId(dialog.builder.itemIds[index]);
+      if (position < dialog.builder.itemIds.length) {
+        view.setId(dialog.builder.itemIds[position]);
       } else {
         view.setId(-1);
       }

--- a/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -1136,6 +1136,7 @@ public class MaterialDialog extends DialogBase
     protected int dividerColor;
     protected int backgroundColor;
     protected int itemColor;
+    protected int[] itemColors;
     protected boolean indeterminateProgress;
     protected boolean showMinMax;
     protected int progress = -2;
@@ -1261,7 +1262,18 @@ public class MaterialDialog extends DialogBase
       return context;
     }
 
+    /**
+     * Use getItemColor(int position) instead
+     */
+    @Deprecated
     public final int getItemColor() {
+      return itemColor;
+    }
+
+    public final int getItemColor(int position) {
+      if (itemColors != null && position < itemColors.length && itemColors[position] != 0) {
+        return itemColors[position];
+      }
       return itemColor;
     }
 
@@ -1535,12 +1547,33 @@ public class MaterialDialog extends DialogBase
       return this;
     }
 
+    public Builder itemsColor(@ColorInt int[] colors) {
+      this.itemColors = colors;
+      return this;
+    }
+
     public Builder itemsColorRes(@ColorRes int colorRes) {
       return itemsColor(DialogUtils.getColor(this.context, colorRes));
     }
 
+    public Builder itemsColorRes(@ColorRes int[] colorsRes) {
+      int[] colors = new int[colorsRes.length];
+      for(int i = 0; i < colorsRes.length ; i++) {
+          colors[i] = colorsRes[i] == 0 ? colorsRes[i] : DialogUtils.getColor(this.context, colorsRes[i]);
+      }
+      return itemsColor(colors);
+    }
+
     public Builder itemsColorAttr(@AttrRes int colorAttr) {
       return itemsColor(DialogUtils.resolveColor(this.context, colorAttr));
+    }
+
+    public Builder itemsColorAttr(@AttrRes int[] colorsAttr) {
+      int[] colors = new int[colorsAttr.length];
+      for(int i = 0; i < colorsAttr.length ; i++) {
+        colors[i] = colorsAttr[i] == 0 ? colorsAttr[i] : DialogUtils.resolveColor(this.context, colorsAttr[i]);
+      }
+      return itemsColor(colors);
     }
 
     public Builder itemsGravity(@NonNull GravityEnum gravity) {

--- a/sample/src/main/java/com/afollestad/materialdialogssample/MainActivity.java
+++ b/sample/src/main/java/com/afollestad/materialdialogssample/MainActivity.java
@@ -220,6 +220,15 @@ public class MainActivity extends AppCompatActivity
         .show();
   }
 
+  @OnClick(R.id.list_multi_colors)
+  public void showListMultiColors() {
+    new MaterialDialog.Builder(this)
+        .items(R.array.actions)
+        .itemsCallback((dialog, view, which, text) -> showToast(which + ": " + text))
+        .itemsColor(new int[] {0, 0, Color.RED})
+        .show();
+  }
+
   @OnClick(R.id.longList)
   public void showLongList() {
     new MaterialDialog.Builder(this)

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -99,6 +99,13 @@
             android:text="@string/list" />
 
         <Button
+            android:id="@+id/list_multi_colors"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/sample_button_height"
+            android:layout_marginTop="@dimen/sample_button_spacing"
+            android:text="@string/basic_list_multi_colors" />
+
+        <Button
             android:id="@+id/longList"
             android:layout_width="match_parent"
             android:layout_height="@dimen/sample_button_height"

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -67,6 +67,12 @@
         <item>Facebook</item>
     </string-array>
 
+    <string-array name="actions">
+        <item>Edit</item>
+        <item>Report</item>
+        <item>Delete</item>
+    </string-array>
+
     <string-array name="socialNetworks_longItems">
         <item>Twitter is an online social networking service that enables users to send and read short 140-character messages called "tweets".</item>
         <item>Google+ is an interest-based social network that is owned and operated by Google Inc. The service is Google\'s fourth foray into social networking.</item>
@@ -201,5 +207,6 @@
     <string name="list_longPress">Basic List (Long Press)</string>
     <string name="add_item">Add Item</string>
     <string name="multiChoiceLimitedMin">Multi Choice (Min Selections)</string>
+    <string name="basic_list_multi_colors">Basic list (multi color items)</string>
 
 </resources>


### PR DESCRIPTION
Current lib just supports `itemsColor(@ColorInt int color)` in builder for custom item color of list item dialog. When I using this lib in my project and want to display an action menu with `focusable item` (difference color). We could custom by using a custom adapter but it's too much works to do than just give a color list.

I added 3 mores builder methods:
- `itemsColor(@ColorInt int[] colors)`
- `itemsColorRes(@ColorRes int[] colorsRes)`
- `itemsColorAttr(@AttrRes int[] colorsAttr)`