### PR TITLE
Add support for 'About Libraries' Android library

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -17,6 +17,7 @@ android {
         versionCode versions.publishVersionCode
         versionName versions.publishVersion
         consumerProguardFiles 'progress-proguard.txt'
+        resValue "string", "library_materialdialogs_libraryVersion", versions.publishVersion
     }
     lintOptions {
         abortOnError false

--- a/core/src/main/res/values/donottranslate_strings_about.xml
+++ b/core/src/main/res/values/donottranslate_strings_about.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="ResourceName">
-    <string name="define_int_materialdialogs">year;owner</string>
+    <string name="define_materialdialogs">year;owner</string>
     <string name="library_materialdialogs_author">Aidan Follestad</string>
     <string name="library_materialdialogs_authorWebsite">http://aidanfollestad.com/</string>
     <string name="library_materialdialogs_libraryName">Material Dialogs</string>

--- a/core/src/main/res/values/donottranslate_strings_about.xml
+++ b/core/src/main/res/values/donottranslate_strings_about.xml
@@ -5,7 +5,7 @@
     <string name="library_materialdialogs_authorWebsite">http://aidanfollestad.com/</string>
     <string name="library_materialdialogs_libraryName">Material Dialogs</string>
     <string name="library_materialdialogs_libraryDescription">A beautiful, easy-to-use, and customizable dialogs API, enabling you to use Material designed
-        dialogs down to API 8
+        dialogs down to API 13 (Honeycomb)
     </string>
     <string name="library_materialdialogs_libraryWebsite">https://github.com/afollestad/material-dialogs</string>
     <string name="library_materialdialogs_isOpenSource">true</string>

--- a/core/src/main/res/values/donottranslate_strings_about.xml
+++ b/core/src/main/res/values/donottranslate_strings_about.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="ResourceName">
+    <string name="define_int_materialdialogs">year;owner</string>
+    <string name="library_materialdialogs_author">Aidan Follestad</string>
+    <string name="library_materialdialogs_authorWebsite">http://aidanfollestad.com/</string>
+    <string name="library_materialdialogs_libraryName">Material Dialogs</string>
+    <string name="library_materialdialogs_libraryDescription">A beautiful, easy-to-use, and customizable dialogs API, enabling you to use Material designed
+        dialogs down to API 8
+    </string>
+    <string name="library_materialdialogs_libraryWebsite">https://github.com/afollestad/material-dialogs</string>
+    <string name="library_materialdialogs_isOpenSource">true</string>
+    <string name="library_materialdialogs_repositoryLink">https://github.com/afollestad/material-dialogs</string>
+    <string name="library_materialdialogs_classPath">com.afollestad.materialdialogs.MaterialDialog</string>
+    <string name="library_materialdialogs_licenseId">mit</string>
+    <string name="library_materialdialogs_owner">Aidan Follestad</string>
+    <string name="library_materialdialogs_year">2016</string>
+</resources>


### PR DESCRIPTION
This is to support [About Libraries](https://github.com/mikepenz/AboutLibraries), a library to facilitate listing dependencies. Your project is currently embedded in that project, which means the version number needs to be manually changed. Having it in your project directly along with the `resValue` in gradle will make this automatic.

These resources will be removed if users have proguard. Those who choose to use about libraries with proguard will keep the R classes to resolve that.

Attached below is an example of how it looks. (Note that the UI can be customized, but the text will be the same throughout projects)

![screenshot_20170723-123845](https://user-images.githubusercontent.com/6251823/28502295-2b87bdc4-6fa4-11e7-8ca2-9ef117669572.png)



