### PR TITLE
Update support lib & build tools to 26.0.1

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,13 +1,13 @@
 ext.versions = [
         minSdk            : 13,
         compileSdk        : 26,
-        buildTools        : '26.0.0',
+        buildTools        : '26.0.1',
         publishVersion    : '0.9.4.5',
         publishVersionCode: 175,
         gradlePlugin      : '3.0.0-alpha7',
         spotlessPlugin    : '3.4.0',
 
-        supportLib        : '25.3.1',
+        supportLib        : '26.0.1',
         mdProgressBar     : '1.4.1',
         butterKnife       : '8.6.0'
 ]


### PR DESCRIPTION
Hey there! Please update the support lib & build tools version to 26.0.1, otherwise gradle will give a headache to anyone trying to use 26.0.1 in their own project along with this library.