### PR TITLE
Moved usage of setButtonTintList for Checkboxes and RadioButtons to API 22

### DIFF
--- a/core/src/main/java/com/afollestad/materialdialogs/internal/MDTintHelper.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/internal/MDTintHelper.java
@@ -27,7 +27,7 @@ import java.lang.reflect.Field;
 public class MDTintHelper {
 
   public static void setTint(@NonNull RadioButton radioButton, @NonNull ColorStateList colors) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
       radioButton.setButtonTintList(colors);
     } else {
       Drawable radioDrawable =
@@ -58,7 +58,7 @@ public class MDTintHelper {
   }
 
   public static void setTint(@NonNull CheckBox box, @NonNull ColorStateList colors) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
       box.setButtonTintList(colors);
     } else {
       Drawable checkDrawable =


### PR DESCRIPTION
There is an issue with using setButtonTintList for API 21, where the radiobuttons and checkboxes that were selected and then deselected retained the accent color (i.e. the selected color). Google was aware of the issue and was fixed in API 22. References can be found at https://issuetracker.google.com/issues/37029454 and https://stackoverflow.com/questions/28047291/api21-setbuttontintlist-on-checkbox

The fix is simply to make sure that APIs 22 and up call this method.