### PR TITLE
Remove support-v13 dependency

### DIFF
--- a/commons/build.gradle
+++ b/commons/build.gradle
@@ -30,7 +30,6 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:support-v13:' + versions.supportLib
     implementation 'com.android.support:appcompat-v7:' + versions.supportLib
     implementation 'com.android.support:support-annotations:' + versions.supportLib
     implementation 'com.android.support:recyclerview-v7:' + versions.supportLib

--- a/commons/src/main/java/com/afollestad/materialdialogs/folderselector/FileChooserDialog.java
+++ b/commons/src/main/java/com/afollestad/materialdialogs/folderselector/FileChooserDialog.java
@@ -11,11 +11,11 @@ import android.os.Environment;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
-import android.support.v13.app.ActivityCompat;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
+import android.support.v4.content.ContextCompat;
 import android.view.View;
 import android.webkit.MimeTypeMap;
 import com.afollestad.materialdialogs.DialogAction;
@@ -138,7 +138,7 @@ public class FileChooserDialog extends DialogFragment implements MaterialDialog.
   @Override
   public Dialog onCreateDialog(Bundle savedInstanceState) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
-        && ActivityCompat.checkSelfPermission(
+        && ContextCompat.checkSelfPermission(
                 getActivity(), Manifest.permission.READ_EXTERNAL_STORAGE)
             != PackageManager.PERMISSION_GRANTED) {
       return new MaterialDialog.Builder(getActivity())

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -32,7 +32,6 @@ android {
 
 dependencies {
     implementation 'com.android.support:support-annotations:' + versions.supportLib
-    implementation 'com.android.support:support-v13:' + versions.supportLib
     implementation 'com.android.support:appcompat-v7:' + versions.supportLib
     implementation 'com.android.support:recyclerview-v7:' + versions.supportLib
     implementation 'me.zhanghai.android.materialprogressbar:library:' + versions.mdProgressBar


### PR DESCRIPTION
Currently there's only one usage of the v13 support library which can be achieved with v4.

This saves pulling another dependency with ~200 referenced methods and fixes recent issues of unmatching support library versions, because v13 is rarely included in projects.