### PR TITLE
Update MaterialProgressBar to v1.4.2

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -8,6 +8,6 @@ ext.versions = [
         spotlessPlugin    : '3.5.1',
 
         supportLib        : '26.0.1',
-        mdProgressBar     : '1.4.1',
+        mdProgressBar     : '1.4.2',
         butterKnife       : '8.8.1'
 ]


### PR DESCRIPTION
This release worked around a framework `ColorFilter` bug when hardware acceleration is enabled on API 18-20.