### PR TITLE
Checkbox prompt text gravity is top? #1507

### DIFF
--- a/core/src/main/res/layout/md_dialog_input_check.xml
+++ b/core/src/main/res/layout/md_dialog_input_check.xml
@@ -74,7 +74,7 @@
       android:layout_marginLeft="@dimen/md_notitle_vertical_padding_more"
       android:layout_marginRight="@dimen/md_notitle_vertical_padding_more"
       android:focusable="true"
-      android:gravity="center"
+      android:gravity="start"
       tools:text="Don't ask again"/>
 
   </LinearLayout>

--- a/core/src/main/res/layout/md_dialog_input_check.xml
+++ b/core/src/main/res/layout/md_dialog_input_check.xml
@@ -74,7 +74,7 @@
       android:layout_marginLeft="@dimen/md_notitle_vertical_padding_more"
       android:layout_marginRight="@dimen/md_notitle_vertical_padding_more"
       android:focusable="true"
-      android:gravity="start"
+      android:gravity="center"
       tools:text="Don't ask again"/>
 
   </LinearLayout>


### PR DESCRIPTION
Hi @afollestad,

I have resolved the bug related to issue[ #1507](https://github.com/afollestad/material-dialogs/issues/1507).

I centered Checkbox label text vertically via changing gravity="start" to gravity="center" 