### PR TITLE
Add StackedTextColor option

### DIFF
--- a/core/src/main/java/com/afollestad/materialdialogs/DialogInit.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/DialogInit.java
@@ -114,6 +114,21 @@ class DialogInit {
           DialogUtils.resolveActionTextColorStateList(
               builder.context, R.attr.md_negative_color, builder.negativeColor);
     }
+    if (!builder.positiveStackedColorSet) {
+      builder.positiveStackedColor =
+          DialogUtils.resolveActionTextColorStateList(
+              builder.context, R.attr.md_positive_stacked_color, builder.positiveStackedColor);
+    }
+    if (!builder.neutralStackedColorSet) {
+      builder.neutralStackedColor =
+          DialogUtils.resolveActionTextColorStateList(
+              builder.context, R.attr.md_neutral_stacked_color, builder.neutralStackedColor);
+    }
+    if (!builder.negativeStackedColorSet) {
+      builder.negativeStackedColor =
+          DialogUtils.resolveActionTextColorStateList(
+              builder.context, R.attr.md_negative_stacked_color, builder.negativeStackedColor);
+    }
     if (!builder.widgetColorSet) {
       builder.widgetColor =
           DialogUtils.resolveColor(builder.context, R.attr.md_widget_color, builder.widgetColor);
@@ -284,7 +299,8 @@ class DialogInit {
     dialog.setTypeface(positiveTextView, builder.mediumFont);
     positiveTextView.setAllCapsCompat(textAllCaps);
     positiveTextView.setText(builder.positiveText);
-    positiveTextView.setTextColor(builder.positiveColor);
+    positiveTextView.setDefaultTextColor(builder.positiveColor, true);
+    positiveTextView.setStackedTextColor(builder.positiveStackedColor);
     dialog.positiveButton.setStackedSelector(dialog.getButtonSelector(DialogAction.POSITIVE, true));
     dialog.positiveButton.setDefaultSelector(
         dialog.getButtonSelector(DialogAction.POSITIVE, false));
@@ -296,6 +312,8 @@ class DialogInit {
     negativeTextView.setAllCapsCompat(textAllCaps);
     negativeTextView.setText(builder.negativeText);
     negativeTextView.setTextColor(builder.negativeColor);
+    negativeTextView.setDefaultTextColor(builder.negativeColor, true);
+    negativeTextView.setStackedTextColor(builder.negativeStackedColor);
     dialog.negativeButton.setStackedSelector(dialog.getButtonSelector(DialogAction.NEGATIVE, true));
     dialog.negativeButton.setDefaultSelector(
         dialog.getButtonSelector(DialogAction.NEGATIVE, false));
@@ -306,7 +324,8 @@ class DialogInit {
     dialog.setTypeface(neutralTextView, builder.mediumFont);
     neutralTextView.setAllCapsCompat(textAllCaps);
     neutralTextView.setText(builder.neutralText);
-    neutralTextView.setTextColor(builder.neutralColor);
+    neutralTextView.setDefaultTextColor(builder.neutralColor, true);
+    neutralTextView.setStackedTextColor(builder.neutralStackedColor);
     dialog.neutralButton.setStackedSelector(dialog.getButtonSelector(DialogAction.NEUTRAL, true));
     dialog.neutralButton.setDefaultSelector(dialog.getButtonSelector(DialogAction.NEUTRAL, false));
     dialog.neutralButton.setTag(DialogAction.NEUTRAL);

--- a/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.java
@@ -1061,6 +1061,9 @@ public class MaterialDialog extends DialogBase
     protected ColorStateList positiveColor;
     protected ColorStateList negativeColor;
     protected ColorStateList neutralColor;
+    protected ColorStateList positiveStackedColor;
+    protected ColorStateList negativeStackedColor;
+    protected ColorStateList neutralStackedColor;
     protected ColorStateList linkColor;
     protected SingleButtonCallback onPositiveCallback;
     protected SingleButtonCallback onNegativeCallback;
@@ -1125,6 +1128,9 @@ public class MaterialDialog extends DialogBase
     protected boolean positiveColorSet = false;
     protected boolean neutralColorSet = false;
     protected boolean negativeColorSet = false;
+    protected boolean positiveStackedColorSet = false;
+    protected boolean neutralStackedColorSet = false;
+    protected boolean negativeStackedColorSet = false;
     protected boolean widgetColorSet = false;
     protected boolean dividerColorSet = false;
 
@@ -1254,6 +1260,15 @@ public class MaterialDialog extends DialogBase
       }
       if (s.negativeColor != null) {
         this.negativeColor = s.negativeColor;
+      }
+      if (s.positiveStackedColor != null) {
+        this.positiveStackedColor = s.positiveStackedColor;
+      }
+      if (s.neutralStackedColor != null) {
+        this.neutralStackedColor = s.neutralStackedColor;
+      }
+      if (s.negativeStackedColor != null) {
+        this.negativeStackedColor = s.negativeStackedColor;
       }
       if (s.itemColor != 0) {
         this.itemColor = s.itemColor;
@@ -1625,6 +1640,25 @@ public class MaterialDialog extends DialogBase
       return this;
     }
 
+    public Builder positiveStackedColor(@ColorInt int color) {
+      return positiveStackedColor(DialogUtils.getActionTextStateList(context, color));
+    }
+
+    public Builder positiveStackedColorRes(@ColorRes int colorRes) {
+      return positiveStackedColor(DialogUtils.getActionTextColorStateList(context, colorRes));
+    }
+
+    public Builder positiveStackedColorAttr(@AttrRes int colorAttr) {
+      return positiveStackedColor(
+          DialogUtils.resolveActionTextColorStateList(context, colorAttr, null));
+    }
+
+    public Builder positiveStackedColor(ColorStateList colorStateList) {
+      this.positiveStackedColor = colorStateList;
+      this.positiveStackedColorSet = true;
+      return this;
+    }
+
     public Builder positiveFocus(boolean isFocusedDefault) {
       this.positiveFocus = isFocusedDefault;
       return this;
@@ -1661,6 +1695,25 @@ public class MaterialDialog extends DialogBase
       return this;
     }
 
+    public Builder negativeStackedColor(@ColorInt int color) {
+      return negativeStackedColor(DialogUtils.getActionTextStateList(context, color));
+    }
+
+    public Builder negativeStackedColorRes(@ColorRes int colorRes) {
+      return negativeStackedColor(DialogUtils.getActionTextColorStateList(context, colorRes));
+    }
+
+    public Builder negativeStackedColorAttr(@AttrRes int colorAttr) {
+      return negativeStackedColor(
+          DialogUtils.resolveActionTextColorStateList(context, colorAttr, null));
+    }
+
+    public Builder negativeStackedColor(ColorStateList colorStateList) {
+      this.negativeStackedColor = colorStateList;
+      this.negativeStackedColorSet = true;
+      return this;
+    }
+
     public Builder negativeText(@StringRes int negativeRes) {
       if (negativeRes == 0) {
         return this;
@@ -1694,6 +1747,25 @@ public class MaterialDialog extends DialogBase
     public Builder neutralColor(ColorStateList colorStateList) {
       this.neutralColor = colorStateList;
       this.neutralColorSet = true;
+      return this;
+    }
+
+    public Builder neutralStackedColor(@ColorInt int color) {
+      return neutralStackedColor(DialogUtils.getActionTextStateList(context, color));
+    }
+
+    public Builder neutralStackedColorRes(@ColorRes int colorRes) {
+      return neutralStackedColor(DialogUtils.getActionTextColorStateList(context, colorRes));
+    }
+
+    public Builder neutralStackedColorAttr(@AttrRes int colorAttr) {
+      return neutralStackedColor(
+          DialogUtils.resolveActionTextColorStateList(context, colorAttr, null));
+    }
+
+    public Builder neutralStackedColor(ColorStateList colorStateList) {
+      this.neutralStackedColor = colorStateList;
+      this.neutralStackedColorSet = true;
       return this;
     }
 

--- a/core/src/main/java/com/afollestad/materialdialogs/internal/MDButton.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/internal/MDButton.java
@@ -2,6 +2,7 @@ package com.afollestad.materialdialogs.internal;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.res.ColorStateList;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.util.AttributeSet;
@@ -21,6 +22,9 @@ public class MDButton extends TextView {
   private int stackedEndPadding;
   private Drawable stackedBackground;
   private Drawable defaultBackground;
+
+  private ColorStateList defaultTextColor;
+  private ColorStateList stackedTextColor;
 
   public MDButton(Context context, AttributeSet attrs) {
     super(context, attrs);
@@ -57,6 +61,12 @@ public class MDButton extends TextView {
         setPadding(stackedEndPadding, getPaddingTop(), stackedEndPadding, getPaddingBottom());
       } /* Else the padding was properly reset by the drawable */
 
+      if (stacked) {
+        setTextColor(stackedTextColor == null ? defaultTextColor : stackedTextColor);
+      } else {
+        setTextColor(defaultTextColor);
+      }
+
       this.stacked = stacked;
     }
   }
@@ -77,6 +87,21 @@ public class MDButton extends TextView {
     if (!stacked) {
       setStacked(false, true);
     }
+  }
+
+  public void setDefaultTextColor(ColorStateList c) {
+    setDefaultTextColor(c, false);
+  }
+
+  public void setDefaultTextColor(ColorStateList c, boolean applyNow) {
+    defaultTextColor = c;
+    if (applyNow) {
+      setTextColor(c);
+    }
+  }
+
+  public void setStackedTextColor(ColorStateList c) {
+    stackedTextColor = c;
   }
 
   public void setAllCapsCompat(boolean allCaps) {

--- a/core/src/main/java/com/afollestad/materialdialogs/internal/ThemeSingleton.java
+++ b/core/src/main/java/com/afollestad/materialdialogs/internal/ThemeSingleton.java
@@ -19,6 +19,9 @@ public class ThemeSingleton {
   public ColorStateList positiveColor = null;
   public ColorStateList neutralColor = null;
   public ColorStateList negativeColor = null;
+  public ColorStateList positiveStackedColor = null;
+  public ColorStateList neutralStackedColor = null;
+  public ColorStateList negativeStackedColor = null;
   @ColorInt public int widgetColor = 0;
   @ColorInt public int itemColor = 0;
   public Drawable icon = null;

--- a/core/src/main/res/values/attrs.xml
+++ b/core/src/main/res/values/attrs.xml
@@ -19,6 +19,9 @@
   <attr name="md_positive_color" format="color" />
   <attr name="md_neutral_color" format="color" />
   <attr name="md_negative_color" format="color" />
+  <attr name="md_positive_stacked_color" format="color" />
+  <attr name="md_neutral_stacked_color" format="color" />
+  <attr name="md_negative_stacked_color" format="color" />
   <attr name="md_widget_color" format="color" />
 
   <attr name="md_item_color" format="color" />


### PR DESCRIPTION
Add `StackedTextColor` options for three action buttons.

**Changes**
- `positiveStackedColor`, `positiveStackedColorRes`, `positiveStackedColorAttr` for positive button
- `negativeStackedColor`, `negativeStackedColorRes`, `negativeStackedColorAttr` for neutral button
- `negativeStackedColor`, `negativeStackedColorRes`, `negativeStackedColorAttr` for negative button
- Attrs: `md_positive_stacked_color`, `md_neutral_stacked_color` and `md_negative_stacked_color`

**Why**

I was build a dialog like this:
![image](https://user-images.githubusercontent.com/12252463/37955201-836eb4a4-31da-11e8-9f04-0a8b4703aa92.png)

But the button text gets long, then this dialog becomes this:
![image](https://user-images.githubusercontent.com/12252463/37955254-b0268a94-31da-11e8-912c-4a475391564c.png)

At first I though the positive button is missing, so I dug a while,  found it's not a bug:
![image](https://user-images.githubusercontent.com/12252463/37955364-fefff2cc-31da-11e8-8574-811d4992e51d.png)

Sure I can change the background with `btnSelectorStacked`, but it's better to offer the option to change text color while it's stacked.