### PR TITLE
remove @CheckResult from MaterialDialog.customView()

### DIFF
--- a/core/src/main/java/com/afollestad/materialdialogs/customview/DialogCustomViewExt.kt
+++ b/core/src/main/java/com/afollestad/materialdialogs/customview/DialogCustomViewExt.kt
@@ -37,7 +37,7 @@ internal const val CUSTOM_VIEW_NO_HORIZONTAL_PADDING = "md.custom_view_no_horizo
  * @param scrollable Whether or not the custom view is automatically wrapped in a ScrollView.
  * @param noVerticalPadding When set to true, vertical padding is not added around your content.
  */
-@CheckResult fun MaterialDialog.customView(
+fun MaterialDialog.customView(
   @LayoutRes viewRes: Int? = null,
   view: View? = null,
   scrollable: Boolean = false,


### PR DESCRIPTION
Hello,
I propose to remove `@CheckResult` from `MaterialDialog.customView()`, because the functionality doesn't really differ from `MaterialDialog.title()` which doesn't have the annotation. But the main reason is that it produces false positive warning

example:

```kotlin
fun foo(){
    val dialog = MaterialDialog(activity!!)
    configureDialog(dialog)
    dialog.show()
}

fun configureDialog(dialog : MaterialDialog){
    val view : View // = ...
    

    dialog
        .title(R.string.title)
        .customView(view = view) // !!! result of customView is not used !!!

    dialog
        .customView(view = view)
        .title(R.string.title) // everything is fine
}
```