### PR TITLE
Fix button measurement

### DIFF
--- a/core/src/main/java/com/afollestad/materialdialogs/internal/button/DialogActionButtonLayout.kt
+++ b/core/src/main/java/com/afollestad/materialdialogs/internal/button/DialogActionButtonLayout.kt
@@ -111,6 +111,11 @@ internal class DialogActionButtonLayout(
     val baseContext = dialogParent().dialog.context
     val appContext = dialogParent().dialog.windowContext
     for (button in visibleButtons) {
+      button.update(
+          baseContext = baseContext,
+          appContext = appContext,
+          stacked = stackButtons
+      )
       if (stackButtons) {
         button.measure(
             makeMeasureSpec(parentWidth, EXACTLY),
@@ -122,11 +127,6 @@ internal class DialogActionButtonLayout(
             makeMeasureSpec(buttonHeightDefault, EXACTLY)
         )
       }
-      button.update(
-          baseContext = baseContext,
-          appContext = appContext,
-          stacked = stackButtons
-      )
     }
 
     if (visibleButtons.isNotEmpty() && !stackButtons) {
@@ -137,14 +137,14 @@ internal class DialogActionButtonLayout(
       if (totalWidth >= parentWidth && !stackButtons) {
         stackButtons = true
         for (button in visibleButtons) {
-          button.measure(
-              makeMeasureSpec(parentWidth, EXACTLY),
-              makeMeasureSpec(buttonHeightStacked, EXACTLY)
-          )
           button.update(
               baseContext = baseContext,
               appContext = appContext,
               stacked = true
+          )
+          button.measure(
+              makeMeasureSpec(parentWidth, EXACTLY),
+              makeMeasureSpec(buttonHeightStacked, EXACTLY)
           )
         }
       }


### PR DESCRIPTION
This should fix problem shown in here: https://github.com/afollestad/material-dialogs/issues/1704

The problem was that when the button layout was measured for the first time, the buttons got some measured width. Then we would call `button.update(...)`, which among other things sets background drawable. However, this drawable adds padding to the button, changing its width. So it could happen, that the first time `onMeasure()` is called the buttons can fit in row next to each other, but the next time they won't and end up stacked in a column. But the dialog already has height from the first measurement and the buttons will not be drawn.