### PR TITLE
Customizing the message: Allow to act on messageTextView directly

### DIFF
--- a/core/src/main/java/com/afollestad/materialdialogs/message/DialogMessageSettings.kt
+++ b/core/src/main/java/com/afollestad/materialdialogs/message/DialogMessageSettings.kt
@@ -43,6 +43,10 @@ class DialogMessageSettings internal constructor(
     return this
   }
 
+  fun getMessageTextView(): TextView {
+    return messageTextView
+  }
+
   internal fun setText(
     @StringRes res: Int?,
     text: CharSequence?


### PR DESCRIPTION
Update the modifier of `messageTextView` in order to make it consistent between the instruction and the implementation.

![image](https://user-images.githubusercontent.com/11498224/61205038-2c412a80-a719-11e9-85ef-50b831308db4.png)

Base on the instruction above, the `messageTextView` should be accessible but it's currently private. 

I created method `getMessageTextView()` to expose it.
