### PR TITLE
Fixed lint project deprecation warnings

### DIFF
--- a/datetime/src/main/java/com/afollestad/materialdialogs/datetime/DatePickerExt.kt
+++ b/datetime/src/main/java/com/afollestad/materialdialogs/datetime/DatePickerExt.kt
@@ -51,7 +51,7 @@ fun MaterialDialog.datePicker(
     maxDate?.let { setMaxDate(it) }
     currentDate?.let { setDate(it) }
 
-    onDateChanged {
+    addOnDateChanged { _, _ ->
       val isFutureDate = getDatePicker().isFutureDate()
       setActionButtonEnabled(
           POSITIVE,

--- a/files/src/main/java/com/afollestad/materialdialogs/files/DialogFileChooserExt.kt
+++ b/files/src/main/java/com/afollestad/materialdialogs/files/DialogFileChooserExt.kt
@@ -18,7 +18,7 @@
 package com.afollestad.materialdialogs.files
 
 import android.annotation.SuppressLint
-import android.os.Environment.getExternalStorageDirectory
+import android.content.Context
 import android.text.InputFilter
 import android.widget.EditText
 import android.widget.TextView
@@ -30,6 +30,7 @@ import com.afollestad.materialdialogs.WhichButton.POSITIVE
 import com.afollestad.materialdialogs.actions.setActionButtonEnabled
 import com.afollestad.materialdialogs.customview.customView
 import com.afollestad.materialdialogs.customview.getCustomView
+import com.afollestad.materialdialogs.files.util.getExternalFilesDir
 import com.afollestad.materialdialogs.files.util.hasReadStoragePermission
 import com.afollestad.materialdialogs.files.util.hasWriteStoragePermission
 import com.afollestad.materialdialogs.input.getInputField
@@ -62,7 +63,8 @@ fun MaterialDialog.selectedFile(): File? {
  */
 @SuppressLint("CheckResult")
 fun MaterialDialog.fileChooser(
-  initialDirectory: File = getExternalStorageDirectory(),
+  context: Context,
+  initialDirectory: File? = context.getExternalFilesDir(),
   filter: FileFilter = null,
   waitForPositiveButton: Boolean = true,
   emptyTextRes: Int = R.string.files_default_empty_text,
@@ -86,6 +88,10 @@ fun MaterialDialog.fileChooser(
     if (filter == null) {
       actualFilter = { !it.isHidden && it.canRead() }
     }
+  }
+
+  check(initialDirectory != null) {
+    "The initial directory is null."
   }
 
   customView(R.layout.md_file_chooser_base, noVerticalPadding = true)

--- a/files/src/main/java/com/afollestad/materialdialogs/files/DialogFolderChooserExt.kt
+++ b/files/src/main/java/com/afollestad/materialdialogs/files/DialogFolderChooserExt.kt
@@ -18,7 +18,7 @@
 package com.afollestad.materialdialogs.files
 
 import android.annotation.SuppressLint
-import android.os.Environment.getExternalStorageDirectory
+import android.content.Context
 import android.widget.TextView
 import androidx.annotation.CheckResult
 import androidx.annotation.StringRes
@@ -28,6 +28,7 @@ import com.afollestad.materialdialogs.WhichButton.POSITIVE
 import com.afollestad.materialdialogs.actions.setActionButtonEnabled
 import com.afollestad.materialdialogs.customview.customView
 import com.afollestad.materialdialogs.customview.getCustomView
+import com.afollestad.materialdialogs.files.util.getExternalFilesDir
 import com.afollestad.materialdialogs.files.util.hasReadStoragePermission
 import com.afollestad.materialdialogs.files.util.hasWriteStoragePermission
 import com.afollestad.materialdialogs.internal.list.DialogRecyclerView
@@ -54,7 +55,8 @@ fun MaterialDialog.selectedFolder(): File? {
  */
 @SuppressLint("CheckResult")
 fun MaterialDialog.folderChooser(
-  initialDirectory: File = getExternalStorageDirectory(),
+  context: Context,
+  initialDirectory: File? = context.getExternalFilesDir(),
   filter: FileFilter = null,
   waitForPositiveButton: Boolean = true,
   emptyTextRes: Int = R.string.files_default_empty_text,
@@ -80,6 +82,10 @@ fun MaterialDialog.folderChooser(
     }
   }
 
+  check(initialDirectory != null) {
+    "The initial directory is null."
+  }
+
   customView(R.layout.md_file_chooser_base, noVerticalPadding = true)
   setActionButtonEnabled(POSITIVE, false)
 
@@ -91,6 +97,7 @@ fun MaterialDialog.folderChooser(
 
   list.attach(this)
   list.layoutManager = LinearLayoutManager(windowContext)
+
   val adapter = FileChooserAdapter(
       dialog = this,
       initialFolder = initialDirectory,

--- a/files/src/main/java/com/afollestad/materialdialogs/files/util/ContextExt.kt
+++ b/files/src/main/java/com/afollestad/materialdialogs/files/util/ContextExt.kt
@@ -18,6 +18,6 @@ package com.afollestad.materialdialogs.files.util
 import android.content.Context
 import java.io.File
 
-fun Context.getExternalFilesDir(): File? {
+internal fun Context.getExternalFilesDir(): File? {
     return this.getExternalFilesDir(null)
 }

--- a/files/src/main/java/com/afollestad/materialdialogs/files/util/ContextExt.kt
+++ b/files/src/main/java/com/afollestad/materialdialogs/files/util/ContextExt.kt
@@ -1,0 +1,23 @@
+/**
+ * Designed and developed by Aidan Follestad (@afollestad)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.afollestad.materialdialogs.files.util
+
+import android.content.Context
+import java.io.File
+
+fun Context.getExternalFilesDir(): File? {
+    return this.getExternalFilesDir(null)
+}

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
       android:name=".SampleApp"
       android:allowBackup="false"
       android:icon="@mipmap/ic_launcher"
+      android:roundIcon="@mipmap/ic_launcher_round"
       android:label="@string/app_name"
       android:supportsRtl="true"
       android:theme="@style/AppTheme"

--- a/sample/src/main/java/com/afollestad/materialdialogssample/MainActivity.kt
+++ b/sample/src/main/java/com/afollestad/materialdialogssample/MainActivity.kt
@@ -878,7 +878,7 @@ class MainActivity : AppCompatActivity() {
 
   private fun showFileChooser() = runWithPermissions(READ_EXTERNAL_STORAGE) {
     MaterialDialog(this).show {
-      fileChooser { _, file ->
+      fileChooser(this@MainActivity) { _, file ->
         toast("Selected file: ${file.absolutePath}")
       }
       debugMode(debugMode)
@@ -888,7 +888,7 @@ class MainActivity : AppCompatActivity() {
 
   private fun showFileChooserButtons() = runWithPermissions(WRITE_EXTERNAL_STORAGE) {
     MaterialDialog(this).show {
-      fileChooser(allowFolderCreation = true) { _, file ->
+      fileChooser(context = this@MainActivity, allowFolderCreation = true) { _, file ->
         toast("Selected file: ${file.absolutePath}")
       }
       negativeButton(android.R.string.cancel)
@@ -900,7 +900,7 @@ class MainActivity : AppCompatActivity() {
 
   private fun showFileChooserFilter() = runWithPermissions(READ_EXTERNAL_STORAGE) {
     MaterialDialog(this).show {
-      fileChooser(filter = { it.extension == "txt" }) { _, file ->
+      fileChooser(context = this@MainActivity, filter = { it.extension == "txt" }) { _, file ->
         toast("Selected file: ${file.absolutePath}")
       }
       debugMode(debugMode)
@@ -910,7 +910,7 @@ class MainActivity : AppCompatActivity() {
 
   private fun showFolderChooserButtons() = runWithPermissions(WRITE_EXTERNAL_STORAGE) {
     MaterialDialog(this).show {
-      folderChooser(allowFolderCreation = true) { _, folder ->
+      folderChooser(context = this@MainActivity, allowFolderCreation = true) { _, folder ->
         toast("Selected folder: ${folder.absolutePath}")
       }
       negativeButton(android.R.string.cancel)
@@ -922,7 +922,7 @@ class MainActivity : AppCompatActivity() {
 
   private fun showFolderChooserFilter() = runWithPermissions(READ_EXTERNAL_STORAGE) {
     MaterialDialog(this).show {
-      folderChooser(filter = { it.name.startsWith("a", true) }) { _, folder ->
+      folderChooser(context = this@MainActivity, filter = { it.name.startsWith("a", true) }) { _, folder ->
         toast("Selected folder: ${folder.absolutePath}")
       }
       debugMode(debugMode)


### PR DESCRIPTION
### Description 
Due the new releases of libraries, was generate some `lint` warnings about deprecation of project methods: 

- **> Lint Task :datetime:compileDebugKotlin**
```
w: /Users/vmadalin/Desktop/AndroidProjects/material-dialogs/datetime/src/main/java/com/afollestad/materialdialogs/datetime/DatePickerExt.kt: (54, 5): 'onDateChanged((date: Calendar) -> Unit): Unit' is deprecated. Use addOnDateChanged instead.
```

- **> Lint Task :files:compileDebugKotlin**
```
w: /Users/vmadalin/Desktop/AndroidProjects/material-dialogs/files/src/main/java/com/afollestad/materialdialogs/files/DialogFileChooserExt.kt: (65, 28): 'getExternalStorageDirectory(): File!' is deprecated. Deprecated in Java
w: /Users/vmadalin/Desktop/AndroidProjects/material-dialogs/files/src/main/java/com/afollestad/materialdialogs/files/DialogFolderChooserExt.kt: (57, 28): 'getExternalStorageDirectory(): File!' is deprecated. Deprecated in Java
w: /Users/vmadalin/Desktop/AndroidProjects/material-dialogs/files/src/main/java/com/afollestad/materialdialogs/files/util/FilesUtilExt.kt: (35, 19): 'getExternalStorageDirectory(): File!' is deprecated. Deprecated in Java
w: /Users/vmadalin/Desktop/AndroidProjects/material-dialogs/files/src/main/java/com/afollestad/materialdialogs/files/util/FilesUtilExt.kt: (45, 5): 'getExternalStorageDirectory(): File!' is deprecated. Deprecated in Java
w: /Users/vmadalin/Desktop/AndroidProjects/material-dialogs/files/src/main/java/com/afollestad/materialdialogs/files/util/FilesUtilExt.kt: (67, 23): 'getExternalStorageDirectory(): File!' is deprecated. Deprecated in Java
w: /Users/vmadalin/Desktop/AndroidProjects/material-dialogs/files/src/main/java/com/afollestad/materialdialogs/files/util/FilesUtilExt.kt: (67, 23): Unsafe use of a nullable receiver of type File?
w: /Users/vmadalin/Desktop/AndroidProjects/material-dialogs/files/src/main/java/com/afollestad/materialdialogs/files/util/FilesUtilExt.kt: (69, 12): 'getExternalStorageDirectory(): File!' is deprecated. Deprecated in Java
```

- **> Lint Task :sample:compileDebugKotlin**
```
w: ../../src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml:2: The resource R.mipmap.ic_launcher_round appears to be unused
```

### Overview 
- Deprecated `onDateChanged()`

> @Deprecated(
>       message = "Use addOnDateChanged instead.",
>       replaceWith = ReplaceWith("addOnDateChanged(block)")
>   )
>   fun onDateChanged(block: (date: Calendar) -> Unit) =
>     controller.addDateChangedListener { _, newDate -> block(newDate) }

- Deprecated `getExternalStorageDirectory()`

> This method was deprecated in API level 29.
> To improve user privacy, direct access to shared/external storage devices is deprecated. When an app targets Build.VERSION_CODES.Q, the path returned from this method is no longer directly accessible to apps. Apps can continue to access content stored on shared/external storage by migrating to alternatives such as Context#getExternalFilesDir(String), MediaStore, or Intent#ACTION_OPEN_DOCUMENT.