### PR TITLE
Expose scrollable property of custom view to input extension

### DIFF
--- a/input/src/main/java/com/afollestad/materialdialogs/input/DialogInputExt.kt
+++ b/input/src/main/java/com/afollestad/materialdialogs/input/DialogInputExt.kt
@@ -80,6 +80,8 @@ private fun MaterialDialog.lookupInputLayout(): TextInputLayout {
  *    the dialog has buttons.
  * @param allowEmpty Defaults to false. When false, the positive action button is disabled unless
  *    the input field is not empty.
+ * @param scrollable Defaults to false. When true, the input field will be added to content
+ *    scrollview.
  * @param callback A listener to invoke for input text notifications.
  */
 @SuppressLint("CheckResult")

--- a/input/src/main/java/com/afollestad/materialdialogs/input/DialogInputExt.kt
+++ b/input/src/main/java/com/afollestad/materialdialogs/input/DialogInputExt.kt
@@ -93,9 +93,10 @@ fun MaterialDialog.input(
   maxLength: Int? = null,
   waitForPositiveButton: Boolean = true,
   allowEmpty: Boolean = false,
+  scrollable: Boolean = false,
   callback: InputCallback = null
 ): MaterialDialog {
-  customView(R.layout.md_dialog_stub_input)
+  customView(viewRes = R.layout.md_dialog_stub_input, scrollable = scrollable)
   onPreShow { showKeyboardIfApplicable() }
   if (!hasActionButtons()) {
     positiveButton(android.R.string.ok)


### PR DESCRIPTION
If the message in the input dialog is longer, then especially in landscape the input field might not be visible and even scrollable to. This exposes the `scrollable` property of customView to `input` extension so if the message is expected to be longer, we can have the input as a part of content scrollview.

Another approach would be to set it always to true for input. I chose this as not to change current behavior.