### PR TITLE
Add missing dependency on kotlin-coroutines-android

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -31,7 +31,7 @@ ext.deps = [
     kotlin: [
         stdlib8: "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
         coroutines: [
-            core: "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2"
+            android: "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.2"
         ]
     ],
 

--- a/files/build.gradle
+++ b/files/build.gradle
@@ -7,6 +7,6 @@ dependencies {
   api project(':core')
   api project(':input')
 
-  implementation deps.kotlin.coroutines.core
+  implementation deps.kotlin.coroutines.android
   implementation deps.kotlin.stdlib8
 }


### PR DESCRIPTION
The files module crashes when it tries to use Dispatchers.Main: [stacktrace](https://gist.github.com/angusholder/0b3c08d81fdd873517d7292c3009f6a7)

I opted for renaming the existing `core` property, as no-one else was using it.
