### PR TITLE
Set hint on TextInputLayout

### DIFF
--- a/input/src/main/java/com/afollestad/materialdialogs/input/DialogInputExt.kt
+++ b/input/src/main/java/com/afollestad/materialdialogs/input/DialogInputExt.kt
@@ -159,7 +159,7 @@ private fun MaterialDialog.styleInput(
   val resources = windowContext.resources
   val editText = getInputField()
 
-  editText.hint = hint ?: if (hintRes != null) resources.getString(hintRes) else null
+  getInputLayout().hint = hint ?: if (hintRes != null) resources.getString(hintRes) else null
   editText.inputType = inputType
   editText.maybeSetTextColor(
       windowContext,


### PR DESCRIPTION
Set hint on `TextInputLayout` instead of `EditText` so that it animates properly when you start typing.

From documentation:
* The hint should be set on the TextInputLayout, rather than the EditText. If a hint is specified
 * on the child EditText in XML, the TextInputLayout might still work correctly; TextInputLayout
 * will use the EditText's hint as its floating label. However, future calls to modify the hint will
 * not update TextInputLayout's hint.

Check the demo here: https://material.io/components/text-fields/