### PR TITLE
Resolve #1960

### DIFF
--- a/core/src/main/java/com/afollestad/materialdialogs/internal/list/MultiChoiceDialogAdapter.kt
+++ b/core/src/main/java/com/afollestad/materialdialogs/internal/list/MultiChoiceDialogAdapter.kt
@@ -110,12 +110,8 @@ internal class MultiChoiceDialogAdapter(
     maxItemAllowed?.let { max ->
       this.items.indices.filter { !currentSelection.contains(it) }.filter {
         it != index || currentSelection.size >= max
-      }
-          .forEach { target ->
-            notifyItemChanged(target)
-          }
+      }.forEach { target -> notifyItemChanged(target) }
     }
-
     if (waitForActionButton && dialog.hasActionButtons()) {
       // Wait for action button, don't call listener
       // so that positive action button press can do so later.

--- a/core/src/main/java/com/afollestad/materialdialogs/list/DialogMultiChoiceExt.kt
+++ b/core/src/main/java/com/afollestad/materialdialogs/list/DialogMultiChoiceExt.kt
@@ -45,6 +45,7 @@ import com.afollestad.materialdialogs.utils.MDUtil.getStringArray
   initialSelection: IntArray = IntArray(0),
   waitForPositiveButton: Boolean = true,
   allowEmptySelection: Boolean = false,
+  maxItemAllowed: Int? = null,
   selection: MultiChoiceListener = null
 ): MaterialDialog {
   assertOneSet("listItemsMultiChoice", items, res)
@@ -72,6 +73,7 @@ import com.afollestad.materialdialogs.utils.MDUtil.getStringArray
           initialSelection = initialSelection,
           waitForActionButton = waitForPositiveButton,
           allowEmptySelection = allowEmptySelection,
+          maxItemAllowed = maxItemAllowed,
           selection = selection
       )
   )

--- a/sample/src/main/java/com/afollestad/materialdialogssample/MainActivity.kt
+++ b/sample/src/main/java/com/afollestad/materialdialogssample/MainActivity.kt
@@ -404,6 +404,21 @@ class MainActivity : AppCompatActivity() {
       }
     }
 
+    R.id.multiple_choice_limited_items.onClickDebounced {
+      MaterialDialog(this).show {
+        title(R.string.socialNetworks)
+        listItemsMultiChoice(
+            R.array.socialNetworks,
+            maxItemAllowed = 2
+        ) { _, indices, text ->
+          toast("Selected items ${text.joinToString()} at indices ${indices.joinToString()}")
+        }
+        positiveButton(R.string.choose)
+        debugMode(debugMode)
+        lifecycleOwner(this@MainActivity)
+      }
+    }
+
     R.id.buttons_stacked.onClickDebounced {
       MaterialDialog(this).show {
         title(R.string.useGoogleLocationServices)

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -205,6 +205,12 @@
         style="@style/SampleButton"
         />
 
+    <Button
+        android:id="@+id/multiple_choice_limited_items"
+        android:text="Multiple Choice, Limited Items"
+        style="@style/SampleButton"
+        />
+
     <!-- Action Buttons -->
 
     <TextView


### PR DESCRIPTION
Resolve #1960 
added param `maxItemAllowed` for controlling the limitation.

I tested the case when more than limitation selected programmatically ( and I intentionally allowed that )

The only problem is when there are more items than the limitation is selected, programmatically and user unselect an item. 
While the selected items are more than the limitation. the uncheck animation for that checkbox would be interrupted. (It changes to fade animation)

One simple solution is to prevent selecting more than limit programmatically
and the other is waiting for unchecking animation to finish before applying the logic which makes the code more complex and IMHO unnecessary.