### PR TITLE
Allow referencing custom fonts by string or as a font resource reference

### DIFF
--- a/core/src/main/java/com/afollestad/materialdialogs/utils/Fonts.kt
+++ b/core/src/main/java/com/afollestad/materialdialogs/utils/Fonts.kt
@@ -16,6 +16,7 @@
 package com.afollestad.materialdialogs.utils
 
 import android.content.Context
+import android.content.res.TypedArray
 import android.graphics.Typeface
 import androidx.annotation.AttrRes
 import androidx.annotation.CheckResult
@@ -35,16 +36,7 @@ import com.afollestad.materialdialogs.utils.MDUtil.assertOneSet
   requireNotNull(attr)
   val a = windowContext.theme.obtainStyledAttributes(intArrayOf(attr))
   try {
-    val resId = a.getResourceId(0, 0)
-    if (resId != 0) {
-      val typeface = safeGetFont(windowContext, resId)
-      if (typeface != null) return typeface
-    }
-    val string = a.getString(0)
-    if (string != null) {
-      return Typeface.create(string, Typeface.NORMAL)
-    }
-    return null
+    return fontFromResIdOrString(windowContext, a)
   } finally {
     a.recycle()
   }
@@ -56,5 +48,23 @@ private fun safeGetFont(context: Context, @FontRes res: Int): Typeface? {
   } catch (e: Throwable) {
     e.printStackTrace()
     null
+  }
+}
+
+private fun fontFromResIdOrString(context: Context, a: TypedArray): Typeface? {
+  try {
+    val resId = a.getResourceId(0, 0)
+    if (resId != 0) {
+      val typeface = safeGetFont(context, resId)
+      if (typeface != null) return typeface
+    }
+    val string = a.getString(0)
+    if (string != null) {
+      return Typeface.create(string, Typeface.NORMAL)
+    }
+    return null
+  } catch (e: Throwable) {
+    e.printStackTrace()
+    return null
   }
 }

--- a/core/src/main/java/com/afollestad/materialdialogs/utils/Fonts.kt
+++ b/core/src/main/java/com/afollestad/materialdialogs/utils/Fonts.kt
@@ -36,8 +36,15 @@ import com.afollestad.materialdialogs.utils.MDUtil.assertOneSet
   val a = windowContext.theme.obtainStyledAttributes(intArrayOf(attr))
   try {
     val resId = a.getResourceId(0, 0)
-    if (resId == 0) return null
-    return safeGetFont(windowContext, resId)
+    if (resId != 0) {
+      val typeface = safeGetFont(windowContext, resId)
+      if (typeface != null) return typeface
+    }
+    val string = a.getString(0)
+    if (string != null) {
+      return Typeface.create(string, Typeface.NORMAL)
+    }
+    return null
   } finally {
     a.recycle()
   }

--- a/core/src/main/res-public/values/public.xml
+++ b/core/src/main/res-public/values/public.xml
@@ -8,9 +8,9 @@
   <attr format="color" name="md_color_widget"/>
   <attr format="color" name="md_color_widget_unchecked"/>
   <attr format="dimension" name="md_corner_radius"/>
-  <attr format="reference" name="md_font_title"/>
-  <attr format="reference" name="md_font_body"/>
-  <attr format="reference" name="md_font_button"/>
+  <attr format="string" name="md_font_title"/>
+  <attr format="string" name="md_font_body"/>
+  <attr format="string" name="md_font_button"/>
   <attr format="float" name="md_line_spacing_body"/>
   <attr format="enum" name="md_button_casing">
     <enum name="upper" value="1"/>

--- a/documentation/CORE.md
+++ b/documentation/CORE.md
@@ -604,7 +604,7 @@ text color of action buttons. If you wish to override these, there are attribute
 
 This library supports using custom fonts, powered by the Support libraries `ResourcesCompat` class. 
 With raw font files or XML font files in your `/res/font` folder, you can use them in Material Dialogs 
-using attributes in your app's theme.
+using attributes in your app's theme. Additionally you can reference system fonts by their name.
 
 ```xml
 <style name="AppTheme.Custom" parent="Theme.AppCompat">


### PR DESCRIPTION
Currently the attributes for custom fonts are limited to font resource references only.
```xml
<item name="md_font_title">@font/your_font</item>
<item name="md_font_body">@font/your_font</item>
<item name="md_font_button">@font/your_font</item>
```
It is not possible to reference system fonts this way (e.g. the Roboto font family).

This PR is inspired by the TextView's [`android:fontFamily`](https://developer.android.com/reference/android/widget/TextView#attr_android:fontFamily) attribute and uses the same logic to resolve the typeface.

This PR will not interference with the current behavior, but it allows to additionally reference fonts by string:
```xml
<item name="md_font_title">sans-serif-black</item>
<item name="md_font_body">sans-serif-light</item>
<item name="md_font_button">@font/your_font</item>
```