### PR TITLE
Attempt to fix issue #2034

### DIFF
--- a/bottomsheets/src/main/java/com/afollestad/materialdialogs/bottomsheets/Util.kt
+++ b/bottomsheets/src/main/java/com/afollestad/materialdialogs/bottomsheets/Util.kt
@@ -33,7 +33,7 @@ internal fun BottomSheetBehavior<*>.setCallbacks(
   onSlide: (currentHeight: Int) -> Unit,
   onHide: () -> Unit
 ) {
-  setBottomSheetCallback(object : BottomSheetCallback() {
+  addBottomSheetCallback(object : BottomSheetCallback() {
     private var currentState: Int = STATE_COLLAPSED
 
     override fun onSlide(


### PR DESCRIPTION
W/BottomSheetBehavior: BottomSheetBehavior now supports multiple callbacks. `setBottomSheetCallback()` removes all existing callbacks, including ones set internally by library authors, which may result in unintended behavior. This may change in the future. Please use `addBottomSheetCallback()` and `removeBottomSheetCallback()` instead to set your own callbacks.