### PR TITLE
Implemented #2018: Added support for multi-lined input fields of a given line count

### DIFF
--- a/input/src/main/java/com/afollestad/materialdialogs/input/DialogInputExt.kt
+++ b/input/src/main/java/com/afollestad/materialdialogs/input/DialogInputExt.kt
@@ -75,7 +75,8 @@ private fun MaterialDialog.lookupInputLayout(): TextInputLayout {
  * @param inputType The input type for the input field, e.g. phone or email. Defaults to plain text.
  * @param maxLength The max length for the input field, shows a counter and disables the positive
  *    action button if the input length surpasses it.
- * @param maxLines The max line length for the input field.
+ * @param maxLines The max line length for the input field. Requires inputType flag
+ *    TYPE_TEXT_FLAG_MULTI_LINE in order to be applied.
  * @param waitForPositiveButton When true, the [callback] isn't invoked until the positive button
  *    is clicked. Otherwise, it's invoked every time the input text changes. Defaults to true if
  *    the dialog has buttons.

--- a/input/src/main/java/com/afollestad/materialdialogs/input/DialogInputExt.kt
+++ b/input/src/main/java/com/afollestad/materialdialogs/input/DialogInputExt.kt
@@ -75,6 +75,7 @@ private fun MaterialDialog.lookupInputLayout(): TextInputLayout {
  * @param inputType The input type for the input field, e.g. phone or email. Defaults to plain text.
  * @param maxLength The max length for the input field, shows a counter and disables the positive
  *    action button if the input length surpasses it.
+ * @param maxLines The max line length for the input field.
  * @param waitForPositiveButton When true, the [callback] isn't invoked until the positive button
  *    is clicked. Otherwise, it's invoked every time the input text changes. Defaults to true if
  *    the dialog has buttons.
@@ -91,6 +92,7 @@ fun MaterialDialog.input(
   @StringRes prefillRes: Int? = null,
   inputType: Int = InputType.TYPE_CLASS_TEXT,
   maxLength: Int? = null,
+  maxLines: Int? = null,
   waitForPositiveButton: Boolean = true,
   allowEmpty: Boolean = false,
   callback: InputCallback = null
@@ -115,6 +117,10 @@ fun MaterialDialog.input(
       counterMaxLength = maxLength
     }
     invalidateInputMaxLength(allowEmpty)
+  }
+
+  if (maxLines != null) {
+    getInputField().maxLines = maxLines
   }
 
   getInputField().textChanged {

--- a/sample/src/main/java/com/afollestad/materialdialogssample/MainActivity.kt
+++ b/sample/src/main/java/com/afollestad/materialdialogssample/MainActivity.kt
@@ -544,6 +544,25 @@ class MainActivity : AppCompatActivity() {
       }
     }
 
+    R.id.input_multiline.onClickDebounced {
+      MaterialDialog(this).show {
+        title(R.string.useGoogleLocationServices)
+        input(
+            hint = "Type something",
+            inputType = InputType.TYPE_CLASS_TEXT or
+                        InputType.TYPE_TEXT_FLAG_CAP_WORDS or
+                        InputType.TYPE_TEXT_FLAG_MULTI_LINE,
+            maxLines = 4
+        ) { _, text ->
+          toast("Input: $text")
+        }
+        positiveButton(R.string.agree)
+        negativeButton(R.string.disagree)
+        debugMode(debugMode)
+        lifecycleOwner(this@MainActivity)
+      }
+    }
+
     R.id.custom_view.onClickDebounced { showCustomViewDialog() }
 
     R.id.custom_view_webview.onClickDebounced { showWebViewDialog() }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -278,6 +278,12 @@
         style="@style/SampleButton"
         />
 
+    <Button
+        android:id="@+id/input_multiline"
+        android:text="Input Multiple Lines"
+        style="@style/SampleButton"
+        />
+
     <!-- Custom Views -->
 
     <TextView


### PR DESCRIPTION
Per issue #2018, It is now possible to have input dialogs that wrap to additional lines. The allowed number of lines that can be displayed at once is declared in the maxLines parameter of input. Any lines beyond maxLines can still be scrolled. Multi-line input fields require the TYPE_TEXT_FLAG_MULTI_LINE inputType to work.

An additional sample, input_multiline, has been created to demonstrate this implementation.