### PR TITLE
Changed logic regarding minDate and maxDate in dateTime module to allow currentDate to be equal to one of them

### DIFF
--- a/datetime/src/main/java/com/afollestad/materialdialogs/datetime/DatePickerExt.kt
+++ b/datetime/src/main/java/com/afollestad/materialdialogs/datetime/DatePickerExt.kt
@@ -27,6 +27,7 @@ import com.afollestad.materialdialogs.customview.customView
 import com.afollestad.materialdialogs.datetime.internal.TimeChangeListener
 import com.afollestad.materialdialogs.datetime.utils.getDatePicker
 import com.afollestad.materialdialogs.datetime.utils.isFutureDate
+import com.afollestad.materialdialogs.datetime.utils.isSameDayAs
 import com.afollestad.materialdialogs.utils.MDUtil.isLandscape
 import java.util.Calendar
 
@@ -93,17 +94,4 @@ fun MaterialDialog.datePicker(
  */
 @CheckResult fun MaterialDialog.selectedDate(): Calendar {
   return getDatePicker().getDate()!!
-}
-
-/**
- * Checks if two calendars are the same day
- */
-fun Calendar.isSameDayAs(other: Calendar): Boolean {
-  val thisDayOfYear = get(Calendar.DAY_OF_YEAR)
-  val thisYear = get(Calendar.YEAR)
-
-  val otherDayOfYear = other.get(Calendar.DAY_OF_YEAR)
-  val otherYear = other.get(Calendar.YEAR)
-
-  return thisDayOfYear == otherDayOfYear && thisYear == otherYear
 }

--- a/datetime/src/main/java/com/afollestad/materialdialogs/datetime/DatePickerExt.kt
+++ b/datetime/src/main/java/com/afollestad/materialdialogs/datetime/DatePickerExt.kt
@@ -98,7 +98,7 @@ fun MaterialDialog.datePicker(
 /**
  * Checks if two calendars are the same day
  */
-fun Calendar.isSameDayAs(other: Calendar) : Boolean {
+fun Calendar.isSameDayAs(other: Calendar): Boolean {
   val thisDayOfYear = get(Calendar.DAY_OF_YEAR)
   val thisYear = get(Calendar.YEAR)
 

--- a/datetime/src/main/java/com/afollestad/materialdialogs/datetime/DatePickerExt.kt
+++ b/datetime/src/main/java/com/afollestad/materialdialogs/datetime/DatePickerExt.kt
@@ -46,10 +46,10 @@ fun MaterialDialog.datePicker(
       dialogWrapContent = windowContext.isLandscape()
   )
 
-  check(minDate == null || currentDate == null || minDate.before(currentDate)) {
+  check(minDate == null || currentDate == null || minDate.isSameDayAs(currentDate) || minDate.before(currentDate)) {
     "Your `minDate` must be less than `currentDate`."
   }
-  check(maxDate == null || currentDate == null || maxDate.after(currentDate)) {
+  check(maxDate == null || currentDate == null || maxDate.isSameDayAs(currentDate) || maxDate.after(currentDate)) {
     "Your `maxDate` must be bigger than `currentDate`."
   }
 
@@ -93,4 +93,17 @@ fun MaterialDialog.datePicker(
  */
 @CheckResult fun MaterialDialog.selectedDate(): Calendar {
   return getDatePicker().getDate()!!
+}
+
+/**
+ * Checks if two calendars are the same day
+ */
+fun Calendar.isSameDayAs(other: Calendar) : Boolean {
+  val thisDayOfYear = get(Calendar.DAY_OF_YEAR)
+  val thisYear = get(Calendar.YEAR)
+
+  val otherDayOfYear = other.get(Calendar.DAY_OF_YEAR)
+  val otherYear = other.get(Calendar.YEAR)
+
+  return thisDayOfYear == otherDayOfYear && thisYear == otherYear
 }

--- a/datetime/src/main/java/com/afollestad/materialdialogs/datetime/utils/DateTimeExt.kt
+++ b/datetime/src/main/java/com/afollestad/materialdialogs/datetime/utils/DateTimeExt.kt
@@ -59,3 +59,16 @@ internal fun toCalendar(
     set(Calendar.MINUTE, timePicker.minute())
   }
 }
+
+/**
+ * Checks if two calendars are the same day
+ */
+internal fun Calendar.isSameDayAs(other: Calendar): Boolean {
+  val thisDayOfYear = get(Calendar.DAY_OF_YEAR)
+  val thisYear = get(Calendar.YEAR)
+
+  val otherDayOfYear = other.get(Calendar.DAY_OF_YEAR)
+  val otherYear = other.get(Calendar.YEAR)
+
+  return thisDayOfYear == otherDayOfYear && thisYear == otherYear
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@ ext.versions = [
     min_sdk: 16,
     compile_sdk: 29,
     build_tools: "29.0.0",
-    publish_version: "3.3.0",
+    publish_version: "3.3.1",
     publish_version_code: 262
 ]
 


### PR DESCRIPTION
### Guidelines 

1. You must run the `spotlessApply` task before commiting, either through Android Studio or with `./gradlew spotlessApply`.
2. A PR should be focused and contained. If you are changing multiple unrelated things, they should be in separate PRs.
3. A PR should fix a bug or solve a problem - something that only you would use is not necessarily something that should be published.
4. Give your PR a detailed title and description - look over your code one last time before actually creating the PR. Give it a self-review.

**If you do not follow the guidelines, your PR will be rejected.**

### PR Description
Changed logic regarding minDate and maxDate in dateTime module to allow currentDate to be equal to one of them.
This is to make it possible to have two dates as allowed dates, and preselect one of them, which was not possible before. The user was able to select one of the two dates, but the code was not allowing preselection of the dates. For example with these dates:
```
minDate = 2021.01.01
maxDate = 2021.01.02
currentDate = 2021.01.01
```