### PR TITLE
Increase title, message and button text sizes in tablet screens

### DIFF
--- a/core/src/main/res/values-sw600dp/dimens.xml
+++ b/core/src/main/res/values-sw600dp/dimens.xml
@@ -2,5 +2,9 @@
 <resources>
 
   <dimen name="md_dialog_max_width">446dp</dimen>
+  
+  <dimen name="md_title_textsize">26sp</dimen>
+  <dimen name="md_message_textsize">24sp</dimen>
+  <dimen name="md_action_button_textsize">18sp</dimen>
 
 </resources>


### PR DESCRIPTION
Updated the sw600dp dimens.xml file to make the dialog's text readable in a tablet's screen. New text size was tested in several tablets.

### Guidelines 

1. You must run the `spotlessApply` task before commiting, either through Android Studio or with `./gradlew spotlessApply`.
2. A PR should be focused and contained. If you are changing multiple unrelated things, they should be in separate PRs.
3. A PR should fix a bug or solve a problem - something that only you would use is not necessarily something that should be published.
4. Give your PR a detailed title and description - look over your code one last time before actually creating the PR. Give it a self-review.

**If you do not follow the guidelines, your PR will be rejected.**
