### PR TITLE
BottomSheet bugfixes (crash, animation)

### DIFF
--- a/bottomsheets/build.gradle
+++ b/bottomsheets/build.gradle
@@ -1,10 +1,10 @@
 ext.module_group = "com.afollestad.material-dialogs"
 ext.module_name = "bottomsheets"
 
-apply from: rootProject.file("gradle/android_library_config.gradle")
+apply from: project.file("../gradle/android_library_config.gradle")
 
 dependencies {
-  api project(':core')
+  api project(':md:core')
 
   implementation deps.kotlin.stdlib8
   implementation deps.google_material

--- a/bottomsheets/src/main/java/com/afollestad/materialdialogs/bottomsheets/BottomSheets.kt
+++ b/bottomsheets/src/main/java/com/afollestad/materialdialogs/bottomsheets/BottomSheets.kt
@@ -79,7 +79,7 @@ fun MaterialDialog.setPeekHeight(
   bottomSheet.defaultPeekHeight = destinationPeekHeight
   val bottomSheetBehavior = bottomSheet.bottomSheetBehavior
   if (isShowing) {
-    bottomSheetBehavior?.animatePeekHeight(
+    bottomSheetBehavior?.animateViewHeight(
         view = this.view,
         dest = destinationPeekHeight,
         duration = LAYOUT_PEEK_CHANGE_DURATION_MS

--- a/bottomsheets/src/main/java/com/afollestad/materialdialogs/bottomsheets/Util.kt
+++ b/bottomsheets/src/main/java/com/afollestad/materialdialogs/bottomsheets/Util.kt
@@ -61,7 +61,7 @@ internal fun BottomSheetBehavior<*>.setCallbacks(
   })
 }
 
-internal fun BottomSheetBehavior<*>.animatePeekHeight(
+internal fun BottomSheetBehavior<*>.animateViewHeight(
   view: View,
   start: Int = peekHeight,
   dest: Int,

--- a/color/build.gradle
+++ b/color/build.gradle
@@ -1,10 +1,10 @@
 ext.module_group = "com.afollestad.material-dialogs"
 ext.module_name = "color"
 
-apply from: rootProject.file("gradle/android_library_config.gradle")
+apply from: project.file("../gradle/android_library_config.gradle")
 
 dependencies {
-  api project(':core')
+  api project(':md:core')
 
   implementation deps.kotlin.stdlib8
   implementation deps.afollestad.dots_indicator

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,7 +1,7 @@
 ext.module_group = "com.afollestad.material-dialogs"
 ext.module_name = "core"
 
-apply from: rootProject.file("gradle/android_library_config.gradle")
+apply from: project.file("../gradle/android_library_config.gradle")
 
 dependencies {
   api deps.androidx.core

--- a/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.kt
+++ b/core/src/main/java/com/afollestad/materialdialogs/MaterialDialog.kt
@@ -17,12 +17,14 @@
 
 package com.afollestad.materialdialogs
 
+import android.app.Activity
 import android.app.Dialog
 import android.content.Context
 import android.graphics.Color.TRANSPARENT
 import android.graphics.Typeface
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
+import android.os.Build
 import android.util.TypedValue
 import android.util.TypedValue.COMPLEX_UNIT_DIP
 import android.view.LayoutInflater
@@ -397,6 +399,9 @@ class MaterialDialog(
   override fun dismiss() {
     if (dialogBehavior.onDismiss()) return
     hideKeyboard()
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && windowContext is Activity && windowContext.isDestroyed) {
+      return
+    }
     super.dismiss()
   }
 

--- a/datetime/build.gradle
+++ b/datetime/build.gradle
@@ -1,10 +1,10 @@
 ext.module_group = "com.afollestad.material-dialogs"
 ext.module_name = "datetime"
 
-apply from: rootProject.file("gradle/android_library_config.gradle")
+apply from: project.file("../gradle/android_library_config.gradle")
 
 dependencies {
-  api project(':core')
+  api project(':md:core')
   api deps.afollestad.date_picker
   compileOnly deps.androidx.annotations
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,15 +1,14 @@
 ext.versions = [
     min_sdk: 16,
     compile_sdk: 29,
-    build_tools: "29.0.0",
     publish_version: "3.3.0",
     publish_version_code: 262
 ]
 
 ext.deps = [
     gradle_plugins: [
-        android: "com.android.tools.build:gradle:4.1.2",
-        kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61",
+        android: "com.android.tools.build:gradle:7.0.1",
+        kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.30",
         spotless: "com.diffplug.spotless:spotless-plugin-gradle:3.27.1",
         versions: "com.github.ben-manes:gradle-versions-plugin:0.27.0"
     ],

--- a/files/build.gradle
+++ b/files/build.gradle
@@ -1,11 +1,11 @@
 ext.module_group = "com.afollestad.material-dialogs"
 ext.module_name = "files"
 
-apply from: rootProject.file("gradle/android_library_config.gradle")
+apply from: project.file("../gradle/android_library_config.gradle")
 
 dependencies {
-  api project(':core')
-  api project(':input')
+  api project(':md:core')
+  api project(':md:input')
 
   implementation deps.kotlin.coroutines.android
   implementation deps.kotlin.stdlib8

--- a/gradle/android_application_config.gradle
+++ b/gradle/android_application_config.gradle
@@ -1,5 +1,5 @@
 apply plugin: "com.android.application"
-apply from: rootProject.file("gradle/android_common_config.gradle")
+apply from: project.file("../gradle/android_common_config.gradle")
 
 if (module_package_id == null) {
   throw new IllegalStateException("module_package_id is missing!")

--- a/gradle/android_common_config.gradle
+++ b/gradle/android_common_config.gradle
@@ -2,12 +2,11 @@ ext.module_package_id = "${module_group}.${module_name}"
 logger.info("Package ID: $module_package_id")
 
 apply plugin: "kotlin-android"
-apply from: rootProject.file("dependencies.gradle")
-apply from: rootProject.file("gradle/spotless_plugin_config.gradle")
+apply from: project.file("../dependencies.gradle")
+//apply from: rootProject.file("gradle/spotless_plugin_config.gradle")
 
 android {
   compileSdkVersion versions.compile_sdk
-  buildToolsVersion versions.build_tools
 
   compileOptions {
     sourceCompatibility 1.8

--- a/gradle/android_library_config.gradle
+++ b/gradle/android_library_config.gradle
@@ -1,4 +1,9 @@
 apply plugin: "com.android.library"
 
 apply from: project.file("../gradle/android_common_config.gradle")
-apply from: project.file("../gradle/android_publish_mavencentral.gradle")
+
+// maven
+//apply from: project.file("../gradle/android_publish_mavencentral.gradle")
+
+// jitpack
+apply from: project.file("../gradle/android_publish_jitpack.gradle")

--- a/gradle/android_library_config.gradle
+++ b/gradle/android_library_config.gradle
@@ -1,4 +1,4 @@
 apply plugin: "com.android.library"
 
-apply from: rootProject.file("gradle/android_common_config.gradle")
-apply from: rootProject.file("gradle/android_publish_mavencentral.gradle")
+apply from: project.file("../gradle/android_common_config.gradle")
+apply from: project.file("../gradle/android_publish_mavencentral.gradle")

--- a/gradle/android_publish_jitpack.gradle
+++ b/gradle/android_publish_jitpack.gradle
@@ -1,0 +1,10 @@
+apply plugin: 'maven-publish'
+project.afterEvaluate {
+  publishing {
+    publications {
+      release(MavenPublication) {
+        from components.release
+      }
+    }
+  }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip

--- a/input/build.gradle
+++ b/input/build.gradle
@@ -1,10 +1,10 @@
 ext.module_group = "com.afollestad.material-dialogs"
 ext.module_name = "input"
 
-apply from: rootProject.file("gradle/android_library_config.gradle")
+apply from: project.file("../gradle/android_library_config.gradle")
 
 dependencies {
-  api project(':core')
+  api project(':md:core')
 
   implementation deps.google_material
   implementation deps.kotlin.stdlib8

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+jdk:
+  - openjdk11
+  - ./gradlew build :lib:publishToMavenLocal

--- a/lifecycle/build.gradle
+++ b/lifecycle/build.gradle
@@ -1,10 +1,10 @@
 ext.module_group = "com.afollestad.material-dialogs"
 ext.module_name = "lifecycle"
 
-apply from: rootProject.file("gradle/android_library_config.gradle")
+apply from: project.file("../gradle/android_library_config.gradle")
 
 dependencies {
-  api project(':core')
+  api project(':md:core')
 
   implementation deps.kotlin.stdlib8
   implementation deps.androidx.lifecycle.runtime

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -6,13 +6,13 @@ apply from: rootProject.file("gradle/android_application_config.gradle")
 android.defaultConfig.vectorDrawables.useSupportLibrary = true
 
 dependencies {
-  implementation project(':core')
-  implementation project(':input')
-  implementation project(':files')
-  implementation project(':color')
-  implementation project(':datetime')
-  implementation project(':bottomsheets')
-  implementation project(':lifecycle')
+  implementation project(':md:core')
+  implementation project(':md:input')
+  implementation project(':md:files')
+  implementation project(':md:color')
+  implementation project(':md:datetime')
+  implementation project(':md:bottomsheets')
+  implementation project(':md:lifecycle')
 
   implementation deps.kotlin.stdlib8
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,16 @@
-include ':core', ':sample', ':files', ':color', ':input', ':lifecycle', ':datetime', ':bottomsheets'
+include ':sample'
+
+include ':md:core'
+project(':md:core').projectDir = new File("core")
+include ':md:input'
+project(':md:input').projectDir = new File("input")
+include ':md:lifecycle'
+project(':md:lifecycle').projectDir = new File("lifecycle")
+include ':md:files'
+project(':md:files').projectDir = new File("files")
+include ':md:color'
+project(':md:color').projectDir = new File("color")
+include ':md:datetime'
+project(':md:datetime').projectDir = new File("datetime")
+include ':md:bottomsheets'
+project(':md:bottomsheets').projectDir = new File("bottomsheets")


### PR DESCRIPTION
Feel free to only merge the bottom sheet changes and the dismiss change.

This does fix following issue:
https://github.com/afollestad/material-dialogs/issues/2076

**Changes**

* Updated MaterialDialog dismiss function to make sure it's only called if the activity is not being finished (only if it is attached to an activity and only on android API >= 17)
* Updated BottomSheet to allow to enable/disable animation and to allow to define an initial state (half expanded, full expanded)
    => animation must be disabled inside a DialogFragment because this fragment will call onShow after screen rotation and also after screen off/on => this leads to collapsed sheets sometimes and to repeated animations on every screen on/off
    => if animation is disabled, everything works perfectly fine inside a DialogFragment as well now

Additionally I would have also done following:
* updated gradle to 7.2
* made the project jitpack compatible again after update to gradle 7 (forks can be retrieved easily via jitpack now)
* made the project compatible to include it as local fork 
  * added a "namespace" to all modules (prefix md)
  * made gradle definitions relative to project instead of root project

**TODO after merge (seems like you do not merge anything anymore, but still here are the steps to undo my "special" changes)**

* Change the maven config back to yours:
https://github.com/MFlisar/material-dialogs/blob/b8f8203513466b1c30dc8046ef5e61a3e61495b5/gradle/android_library_config.gradle#L6-L9
* Enable spotless again (I don't use spotless and so I disabled this plugin, it does not work out of the box in a local fork the way its set up in your repo)
https://github.com/MFlisar/material-dialogs/blob/b8f8203513466b1c30dc8046ef5e61a3e61495b5/gradle/android_common_config.gradle#L6

**Note**

If someone else wants to use it already, it's already published on jitpack and can be used like following:

    implementation "com.github.MFlisar.material-dialogs:core:3.3.0-1"
    ....